### PR TITLE
enable partial support for symlinks

### DIFF
--- a/install_samba.sh
+++ b/install_samba.sh
@@ -33,6 +33,8 @@ sudo patch <<'EOF'
 +create mask = 0644
 +directory mask = 0755
 +force user = homeassistant
++follow symlinks = yes
++wide links = yes
 +
 EOF
 


### PR DESCRIPTION
allow traversal of symlinks
+follow symlinks = yes
+wide links = yes

this also requires an additional entry under global

[global]
#allow traveral of symlinks
allow insecure wide links = yes

perhaps someone can use sed or awk to insert it in correct spot?

http://unix.stackexchange.com/questions/5120/how-do-you-make-samba-follow-symlink-outside-the-shared-path

perhaps someone can use sed or awk to insert it in correct spot?