### PR TITLE
Update install_libcec.sh

### DIFF
--- a/install_libcec.sh
+++ b/install_libcec.sh
@@ -58,7 +58,7 @@ sudo make install
 sudo ldconfig
 
 echo "Linking libcec to venv site packages"
-sudo -u homeassistant ln -s /usr/local/lib/python3.*/site-packages/cec /srv/homeassistant/lib/python3.*/site-packages/
+sudo -u homeassistant ln -s /usr/local/lib/python3.*/dist-packages/cec /srv/homeassistant/lib/python3.*/site-packages/
 
 echo
 echo "Installation done."


### PR DESCRIPTION
Looks like CEC is installed in dist-packages now instead of site-packages. Updated documentation here -> https://home-assistant.io/components/hdmi_cec/