### PR TITLE
OpenZwave config directory location

### DIFF
--- a/opt/hassbian/suites/install_openzwave.sh
+++ b/opt/hassbian/suites/install_openzwave.sh
@@ -96,7 +96,6 @@ chown -R homeassistant:homeassistant /srv/homeassistant/src
 echo "Linking Home Assistant OpenZWave config directory"
 cd /home/homeassistant/.homeassistant
 sudo -u homeassistant ln -sd /srv/homeassistant/lib/python3.*/site-packages/python_openzwave/ozw_config
-
 chown -R homeassistant:homeassistant /home/homeassistant/.homeassistant
 
 echo

--- a/opt/hassbian/suites/install_openzwave.sh
+++ b/opt/hassbian/suites/install_openzwave.sh
@@ -90,12 +90,13 @@ chown homeassistant:homeassistant Makefile
 make
 
 echo "Linking ozwcp config directory"
-ln -sd /srv/homeassistant/lib/python3.*/site-packages/libopenzwave-0.*-linux*.egg/config
+ln -sd /srv/homeassistant/lib/python3.*/site-packages/python_openzwave/ozw_config
 chown -R homeassistant:homeassistant /srv/homeassistant/src
 
 echo "Linking Home Assistant OpenZWave config directory"
 cd /home/homeassistant/.homeassistant
-sudo -u homeassistant ln -sd /srv/homeassistant/lib/python3.*/site-packages/libopenzwave-*-linux*.egg/config
+sudo -u homeassistant ln -sd /srv/homeassistant/lib/python3.*/site-packages/python_openzwave/ozw_config
+
 chown -R homeassistant:homeassistant /home/homeassistant/.homeassistant
 
 echo


### PR DESCRIPTION
I'm not sure if I was having a moment or if OpenZWave 0.40 caused this, but after using `hassbian-config install openzwave` tonight, Zwave did not run with HA. 

After checking things out, it looks like the `/srv/homeassistant/lib/python3.*/site-packages/libopenzwave-0.*-linux*.egg/config` folder does not exist. I did find the openzwave config information in ` /srv/homeassistant/lib/python3.*/site-packages/python_openzwave/ozw_config`. When I changed the links to that folder and used the config path `/srv/homeassistant/src/python-openzwave/openzwave/config` in my HA configuration file everything is working great. 

Might be worth double checking before merging this, but just wanted to point it out. Cheers!