### PR TITLE
Throw Error If Running User Is Not root

### DIFF
--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -163,6 +163,12 @@ function get-suite-state-info {
    echo $json
 }
 
+if (( $EUID != 0 ))
+then
+  echo "Error: hassbian-config must be as root (with sudo)"
+  exit 1
+fi
+
 if [ $# -lt 1 ]
 then
    usage


### PR DESCRIPTION
I was getting some strange permission errors that were not super apparent when trying to run : 

```
hasbian-config install openzwave
```

Looking at the README now, all the examples have `sudo` in front of them, but an error would have saved me a few minutes of fiddling with things.

PS: I've only just started playing around with everything, but it seems awesome! Very cool project.