### PR TITLE
Added support for upgrade scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,17 @@ hassbian-config *command* *suite*
 ```
 where command is one of:
 - `install`
+- `upgrade`
 - `show`
 
 ##### install
 The install command takes one argument and will attempt to install the indicated suite of software.
 Generally, this means that the invocation of `hassbian-config` should be run as root, with:
 `sudo hassbian-config install *suite*`
+##### upgrade
+The install command takes one argument and will attempt to install the indicated suite of software.
+Generally, this means that the invocation of `hassbian-config` should be run as root, with:
+`sudo hassbian-config upgrade *suite*`
 ##### show
 The show command can be run without arguments, and lists all available suites which can be installed or with a *suite* name as argument and shows information about the suite .
 

--- a/package/opt/hassbian/suites/upgrade_hassbian-script.sh
+++ b/package/opt/hassbian/suites/upgrade_hassbian-script.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+function hassbian-script-show-short-info {
+    echo "Hassbian-Script upgrade script for Hassbian"
+}
+
+function hassbian-script-show-long-info {
+    echo "Upgrade hassbian-scripts."
+}
+
+function hassbian-script-show-copyright-info {
+    echo "Original consept by Ludeeus <https://github.im/Ludeeus>"
+}
+
+function hassbian-script-upgrade-package {
+hassbian-script-show-short-info
+hassbian-script-show-copyright-info
+
+echo "Moving to temp folder"
+cd /tmp
+
+echo "Downloading newest release"
+curl https://api.github.com/repos/home-assistant/hassbian-scripts/releases/latest | grep "browser_download_url.*deb" | cut -d : -f 2,3 | tr -d \" | wget -qi -
+
+echo "Setting package name"
+HASSBIAN_PACKAGE=$(ls | grep 'hassbian*')
+
+echo "Installing the package"
+sudo dpkg -i $HASSBIAN_PACKAGE
+
+echo "Cleanup"
+rm $HASSBIAN_PACKAGE
+
+echo
+echo "Uppgrade is now done."
+echo
+echo
+echo "If you have issues with this script, please say something in the #Hassbian channel on Discord."
+echo
+return 0
+}
+
+# Make this script function as it always has if run standalone, rather than issue a warning and do nothing.
+[[ $0 == "$BASH_SOURCE" ]] && hassbian-script-upgrade-package

--- a/package/opt/hassbian/suites/upgrade_hassbian-script.sh
+++ b/package/opt/hassbian/suites/upgrade_hassbian-script.sh
@@ -8,14 +8,14 @@ function hassbian-script-show-long-info {
 }
 
 function hassbian-script-show-copyright-info {
-    echo "Original consept by Ludeeus <https://github.im/Ludeeus>"
+    echo "Original concept by Ludeeus <https://github.im/Ludeeus>"
 }
 
 function hassbian-script-upgrade-package {
 hassbian-script-show-short-info
 hassbian-script-show-copyright-info
 
-echo "Moving to temp folder"
+echo "Moving to temporary folder"
 cd /tmp
 
 echo "Downloading newest release"

--- a/package/opt/hassbian/suites/upgrade_home-assistant.sh
+++ b/package/opt/hassbian/suites/upgrade_home-assistant.sh
@@ -12,7 +12,7 @@ function home-assistant-show-copyright-info {
     echo "Modyfied by Ludeeus <https://github.im/Ludeeus>"
 }
 
-function home-assistant-package {
+function home-assistant-upgrade-package {
 home-assistant-show-short-info
 home-assistant-show-copyright-info
 
@@ -50,4 +50,4 @@ return 0
 }
 
 # Make this script function as it always has if run standalone, rather than issue a warning and do nothing.
-[[ $0 == "$BASH_SOURCE" ]] && home-assistant-package
+[[ $0 == "$BASH_SOURCE" ]] && home-assistant-upgrade-package

--- a/package/opt/hassbian/suites/upgrade_home-assistant.sh
+++ b/package/opt/hassbian/suites/upgrade_home-assistant.sh
@@ -4,11 +4,11 @@ function home-assistant-show-short-info {
 }
 
 function home-assistant-show-long-info {
-    echo "Upgrade the base home assistant package onto this system."
+    echo "Upgrade the base Home Assistant package onto this system."
 }
 
 function home-assistant-show-copyright-info {
-    echo "Original consept by Landrash <https://github.com/Landrash>"
+    echo "Original concept by Landrash <https://github.com/Landrash>"
     echo "Modyfied by Ludeeus <https://github.im/Ludeeus>"
 }
 
@@ -36,12 +36,12 @@ echo "Deactivating virtualenv"
 deactivate
 EOF
 
-echo "Starting Home Assistant"
+echo "Restarting Home Assistant"
 systemctl start home-assistant@homeassistant.service
 
 echo
 echo "Uppgrade is now done."
-echo "Note that sometimes it takes a while to start up after an upgrade."
+echo "Note tha it may take some time to start up after an upgrade."
 echo
 echo
 echo "If you have issues with this script, please say something in the #Hassbian channel on Discord."

--- a/package/opt/hassbian/suites/upgrade_home-assistant.sh
+++ b/package/opt/hassbian/suites/upgrade_home-assistant.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
-function homeassistant-upgrade-show-short-info {
+function home-assistant-show-short-info {
     echo "Home Assistant upgrade script for Hassbian"
 }
 
-function homeassistant-upgrade-show-long-info {
-    echo "Upgrade the base homeassistant package onto this system."
+function home-assistant-show-long-info {
+    echo "Upgrade the base home assistant package onto this system."
 }
 
-function homeassistant-upgrade-show-copyright-info {
+function home-assistant-show-copyright-info {
     echo "Original consept by Landrash <https://github.com/Landrash>"
     echo "Modyfied by Ludeeus <https://github.im/Ludeeus>"
 }
 
-function homeassistant-upgrade-package {
-homeassistant-upgrade-show-short-info
-homeassistant-upgrade-show-copyright-info
+function home-assistant-package {
+home-assistant-show-short-info
+home-assistant-show-copyright-info
 
 
 echo "Stopping Home Assistant"
@@ -50,4 +50,4 @@ return 0
 }
 
 # Make this script function as it always has if run standalone, rather than issue a warning and do nothing.
-[[ $0 == "$BASH_SOURCE" ]] && homeassistant-upgrade-package
+[[ $0 == "$BASH_SOURCE" ]] && home-assistant-package

--- a/package/opt/hassbian/suites/upgrade_homeassistant.sh
+++ b/package/opt/hassbian/suites/upgrade_homeassistant.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+function homeassistant-upgrade-show-short-info {
+    echo "Home Assistant upgrade script for Hassbian"
+}
+
+function homeassistant-upgrade-show-long-info {
+    echo "Upgrade the base homeassistant package onto this system."
+}
+
+function homeassistant-upgrade-show-copyright-info {
+    echo "Original consept by Landrash <https://github.com/Landrash>"
+    echo "Modyfied by Ludeeus <https://github.im/Ludeeus>"
+}
+
+function homeassistant-upgrade-package {
+homeassistant-upgrade-show-short-info
+homeassistant-upgrade-show-copyright-info
+
+
+echo "Stopping Home Assistant"
+systemctl stop home-assistant@homeassistant.service
+
+echo "Changing to the homeassistant user"
+sudo -u homeassistant -H /bin/bash << EOF
+
+echo "Creating Home Assistant venv"
+python3 -m venv /srv/homeassistant
+
+echo "Changing to Home Assistant venv"
+source /srv/homeassistant/bin/activate
+
+echo "Installing latest version of Home Assistant"
+pip3 install --upgrade homeassistant
+
+echo "Deactivating virtualenv"
+deactivate
+EOF
+
+echo "Starting Home Assistant"
+systemctl start home-assistant@homeassistant.service
+
+echo
+echo "Uppgrade is now done."
+echo "Note that sometimes it takes a while to start up after an upgrade."
+echo
+echo
+echo "If you have issues with this script, please say something in the #Hassbian channel on Discord."
+echo
+return 0
+}
+
+# Make this script function as it always has if run standalone, rather than issue a warning and do nothing.
+[[ $0 == "$BASH_SOURCE" ]] && homeassistant-upgrade-package

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -22,7 +22,7 @@ function show-suite-info {
 }
 
 function get-all-suite-installers {
-   echo $(ls /opt/hassbian/suites/*.sh | grep -v 'install_homeassistant.sh' | awk -F'/|_' ' {print $NF}' | awk -F. '{print $1}')
+   echo $(ls $SUITE_INSTALL_DIR/*.sh | grep -v 'install_homeassistant.sh' | awk -F'/|_' ' {print $NF}' | awk -F. '{print $1}')
 }
 
 function show-suites {
@@ -127,7 +127,7 @@ function upgrade-suite {
 
 function verify-suite {
    # Check that the suite specified actually exists
-   if [ -f "$SUITE_INSTALL_DIR/install_$1.sh" ]; 
+   if [ -f "$SUITE_INSTALL_DIR/install_$1.sh" ]
    then
       retval=0 # beware - 0 is true in bash.
    elif [ -f "$SUITE_INSTALL_DIR/upgrade_$1.sh" ]

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -10,18 +10,19 @@ function usage {
    echo $0 \<command\> \<suite\>
    echo where \<command\> is one of:
    echo     install  - installs a software suite
+   echo     upgrade  - upgrades a software suite
    echo     show     - shows software suites available
    echo and \<suite\> is the name of a software component to operate on.
    echo
 }
 
 function show-suite-info {
-   source $SUITE_INSTALL_DIR/install_$1.sh
+   source $SUITE_INSTALL_DIR/*_$1.sh
    $1-show-long-info
 }
 
 function get-all-suite-installers {
-   echo $(ls $SUITE_INSTALL_DIR/install_*.sh | grep -Po "install_\K(.*)\.sh$" | awk -F. '!/homeassistant/ {print $1}')
+   echo $(ls /opt/hassbian/suites/*.sh | grep -v 'install_homeassistant.sh' | awk -F'/|_' ' {print $NF}' | awk -F. '{print $1}')
 }
 
 function show-suites {
@@ -36,7 +37,7 @@ function show-suites {
 
 function show-suite-long-info {
    # Shows long info for the suite.
-   source $SUITE_INSTALL_DIR/install_$1.sh
+   source $SUITE_INSTALL_DIR/*_$1.sh
    $1-show-short-info
    $1-show-long-info
    $1-show-copyright-info
@@ -112,11 +113,26 @@ function install-suite {
    fi
 }
 
+function upgrade-suite {
+   # Having got here, the installer script exists; source it, then run the installer function.
+   update-suite-state "$1" "upgrading"
+   source $SUITE_INSTALL_DIR/upgrade_$1.sh
+   if $1-upgrade-package
+   then
+      update-suite-state "$1" "upgraded"
+   else
+      update-suite-state "$1" "failed"
+   fi
+}
+
 function verify-suite {
    # Check that the suite specified actually exists
-   if [ -f "$SUITE_INSTALL_DIR/install_$1.sh" ]
+   if [ -f "$SUITE_INSTALL_DIR/install_$1.sh" ]; 
    then
       retval=0 # beware - 0 is true in bash.
+   elif [ -f "$SUITE_INSTALL_DIR/upgrade_$1.sh" ]
+   then
+      retval=0
    else
       retval=1
    fi
@@ -202,6 +218,15 @@ case $COMMAND in
    else
       echo "suite $SUITE doesn't exist."
    fi
+   ;;
+"upgrade")
+   if verify-suite $SUITE
+   then
+      upgrade-suite $SUITE
+   else
+      echo "suite $SUITE doesn't exist."
+   fi
+   exit
    ;;
 "state")
    get-suite-state-info $SUITE


### PR DESCRIPTION
- Changed MD to show new function `upgrade`
- Changed hassbian-config to support `upgrade`

Added upgrade script for:
- Home Asssistant
- Hassbian-Scripts

Tested functionality:
`hassbian-script show`
`hassbian-script show home-assistant`
`hassbian-script show hassbian-script`
`sudo hassbian-script upgrade home-assistant`
`sudo hassbian-script upgrade hassbian-script`