### PR TITLE
Added installation script for an web terminal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,19 @@ sudo hassbian-config install tradfri
 ```
 This script was originally contributed by [@Landrash](https://github.com/Landrash).
 
+### Install an web terminal for easy access to ssh in an web browser *(install_webterminal.sh)*
+This script installs an web terminal called 'shellinabox' to you system that give you SHH access in you web browser.
+
+Script is run as the `pi` user with the following command:
+```
+sudo hassbian-config install webterminal
+```
+Example config for Home-Assistant:
+```yaml
+panel_iframe:
+  terminal:
+    title: 'Terminal'
+    icon: mdi:console
+    url: 'http://192.168.1.2:4200'
+```
+This script was originally contributed by [@Ludeeus](https://github.com/Ludeeus).

--- a/package/opt/hassbian/suites/install_webterminal.sh
+++ b/package/opt/hassbian/suites/install_webterminal.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+function webterminal-show-short-info {
+    echo "Installs an websevice terminal."
+}
+
+function webterminal-show-long-info {
+    echo "Installs an websevice terminal to controll your installation."
+}
+
+function webterminal-show-copyright-info {
+	echo "Original consept by Ludeeus <https://github.com/ludeeus>"
+}
+
+function webterminal-install-package {
+echo "Installing packages."
+sudo apt-get install -y openssl shellinabox
+
+echo "Changing config."
+sudo sed -i 's/--no-beep/--no-beep --disable-ssl/g' /etc/default/shellinabox
+
+echo "Reloading and starting the service."
+sudo service shellinabox reload
+sudo service shellinabox restart
+
+ip_address=$(ifconfig | grep "inet.*broadcast" | grep -v 0.0.0.0 | awk '{print $2}')
+
+echo
+echo "Installation done."
+echo
+echo "You can now access the web terminal here: http://$ip_address:4200"
+echo "You can also add this to your Home-Assistant config in an 'panel_iframe'"
+echo
+echo "If you have issues with this script, please say something in the #Hassbian channel on Discord."
+echo
+return 0
+}
+
+# Make this script function as it always has if run standalone, rather than issue a warning and do nothing.
+[[ $0 == "$BASH_SOURCE" ]] && webterminal-install-package


### PR DESCRIPTION
Output from the installation:
```
sudo hassbian-config install webterminal
Installing packages.
Reading package lists... Done
Building dependency tree
Reading state information... Done
openssl is already the newest version (1.1.0f-3).
openssl set to manually installed.
The following NEW packages will be installed:
  shellinabox
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 116 kB of archives.
After this operation, 496 kB of additional disk space will be used.
Get:1 http://raspbian.trivini.no/raspbian stretch/main armhf shellinabox armhf 2.20 [116 kB]
Fetched 116 kB in 1s (70.9 kB/s)
Selecting previously unselected package shellinabox.
(Reading database ... 39832 files and directories currently installed.)
Preparing to unpack .../shellinabox_2.20_armhf.deb ...
Unpacking shellinabox (2.20) ...
Setting up shellinabox (2.20) ...
Processing triggers for systemd (232-25+deb9u1) ...
Processing triggers for man-db (2.7.6.1-2) ...
Changing config.
Reloading and starting the service.

Installation done.

You can now access the web terminal here: http://192.168.1.2:4200
You can also add this to your Home-Assistant config in an 'panel_iframe'

If you have issues with this script, please say something in the #Hassbian channel on Discord.
```

From Home-Assistant with sample config:
![image](https://user-images.githubusercontent.com/15093472/30427644-cefe4812-9950-11e7-8c4e-98851e27c3d5.png)
