### PR TITLE
Fixed problem when running on stretch

### DIFF
--- a/package/opt/hassbian/suites/install_mosquitto.sh
+++ b/package/opt/hassbian/suites/install_mosquitto.sh
@@ -48,6 +48,7 @@ apt install -y mosquitto mosquitto-clients
 if [[ $? > 0 ]]
 then
    echo "First try failed, adding dependencies and trying again."
+   echo "This is an workaround and will be omited once it's fixed upstream."
    echo "Downloading dependencies"
    cd
    wget http://ftp.se.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u6_armhf.deb

--- a/package/opt/hassbian/suites/install_mosquitto.sh
+++ b/package/opt/hassbian/suites/install_mosquitto.sh
@@ -44,6 +44,29 @@ echo "Installing mosquitto"
 apt-get update
 apt install -y mosquitto mosquitto-clients
 
+
+if [[ $? > 0 ]]
+then
+   echo "First try failed, adding dependencies and trying again."
+   echo "Downloading dependencies"
+   cd
+   wget http://ftp.se.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u6_armhf.deb
+   wget http://ftp.se.debian.org/debian/pool/main/libw/libwebsockets/libwebsockets3_1.2.2-1_armhf.deb
+
+   echo "Installing dependencies"
+   sudo dpkg -i libssl1.0.0_1.0.1t-1+deb8u6_armhf.deb
+   sudo dpkg -i libwebsockets3_1.2.2-1_armhf.deb
+
+   echo "Cleanup dependencies"
+   rm libssl1.0.0_1.0.1t-1+deb8u6_armhf.deb
+   rm libwebsockets3_1.2.2-1_armhf.deb
+   
+   echo "Retrying installation of mosquitto"
+   apt install -y mosquitto mosquitto-clients
+else
+    echo ""
+fi
+
 echo "Writing default configuration"
 cd /etc/mosquitto
 mv mosquitto.conf mosquitto.conf.backup


### PR DESCRIPTION
These additions will do this:
- Try running it normally (so if this is fixed upstream, we don't need the rest of the additions in the future)
- If first tryf fails, missing dependencies are downloaded, and the installer runs 1 more time.

Testet with the current version on Hassbian 1.3
This will fix part of issue #39 