### PR TITLE
Attempt to fix Tradfri after 0.55

### DIFF
--- a/package/opt/hassbian/suites/install_tradfri.sh
+++ b/package/opt/hassbian/suites/install_tradfri.sh
@@ -28,20 +28,29 @@ apt-get install -y libtool autoconf
 echo "Changing to homeassistant user"
 sudo -u homeassistant -H /bin/bash <<EOF
 
+
 echo "Creating source directory"
 mkdir -p /srv/homeassistant/src
 chown -R homeassistant:homeassistant /srv/homeassistant/src
 
+echo "Cloning modified tinydtls library"
+cd /srv/homeassistant/src
+git clone --depth 1 https://git.fslab.de/jkonra2m/tinydtls.git
+cd tinydtls
+cp configure.in configure.ac
+autoreconf
+./configure --with-ecc --without-debug
+cd cython
+echo "Installingmodified tinydtls library"
+python3 setup.py install
+
 echo "Cloning modified lib-coap library"
 cd /srv/homeassistant/src
-git clone --depth 1 --recursive -b dtls https://github.com/home-assistant/libcoap.git
-chown -R homeassistant:homeassistant libcoap
-
-echo "Building lib-coap library"
-cd libcoap
-./autogen.sh
-./configure --disable-documentation --disable-shared --without-debug CFLAGS="-D COAP_DEBUG_FD=stderr"
-make
+git clone https://github.com/chrysn/aiocoap
+cd aiocoap
+git reset --hard 3286f48f0b949901c8b5c04c0719dc54ab63d431
+echo "Installing modified lib-coap library"
+python3 -m pip install .
 EOF
 
 echo "Installing lib-coap library"


### PR DESCRIPTION
Tradfri was brooken on Hassbian after https://github.com/home-assistant/home-assistant/pull/7815 .
 This attempts to fix that.