### PR TITLE
Making sure wheel and setuptools are up to date

### DIFF
--- a/package/opt/hassbian/suites/upgrade_home-assistant.sh
+++ b/package/opt/hassbian/suites/upgrade_home-assistant.sh
@@ -27,6 +27,7 @@ echo "Changing to Home Assistant venv"
 source /srv/homeassistant/bin/activate
 
 echo "Installing latest version of Home Assistant"
+pip3 install --upgrade setuptools wheel
 pip3 install --upgrade homeassistant
 
 echo "Deactivating virtualenv"


### PR DESCRIPTION
I had the same issue when installing cython for tradfri.
I think only wheel is required, but added setuptools for good messure :)

Ref: https://community.home-assistant.io/t/upgrade-to-0-55-error-failed-building-wheel-for-yarl/29188