### PR TITLE
Remove cython from base package since it's installed as a pip package

### DIFF
--- a/package/DEBIAN/control
+++ b/package/DEBIAN/control
@@ -1,7 +1,7 @@
 Package: hassbian-scripts
 Architecture: all
 Maintainer: Fredrik Lindqvist <github.com/Landrash>
-Depends: bash, wget, git, python3, python3-venv, python3-pip, python3-dev, bluetooth, libbluetooth-dev, avahi-daemon, build-essential, libssl-dev, libffi-dev, python-dev, libudev-dev, cython3
+Depends: bash, wget, git, python3, python3-venv, python3-pip, python3-dev, bluetooth, libbluetooth-dev, avahi-daemon, build-essential, libssl-dev, libffi-dev, python-dev, libudev-dev
 Priority: optional
 Homepage: www.home-assistant.io
 Version: 0.6


### PR DESCRIPTION
Removes the `cython3` package dependency.