### PR TITLE
Update upgrade_hassbian.sh

### DIFF
--- a/package/opt/hassbian/suites/upgrade_hassbian.sh
+++ b/package/opt/hassbian/suites/upgrade_hassbian.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 function hassbian-show-short-info {
-    echo "Home Assistant upgrade script for Hassbian"
+    echo "Upgrade the base OS installation on this system"
 }
 
 function hassbian-show-long-info {


### PR DESCRIPTION
As of now, sudo hassbian-config show gives same description for hassbian and home-assistant upgrade script. Perhaps this is confusing that the short description is the same for both scripts?