### PR TITLE
Update upgrade_home-assistant.sh

### DIFF
--- a/package/opt/hassbian/suites/upgrade_home-assistant.sh
+++ b/package/opt/hassbian/suites/upgrade_home-assistant.sh
@@ -16,6 +16,25 @@ function home-assistant-upgrade-package {
 home-assistant-show-short-info
 home-assistant-show-copyright-info
 
+echo "Checking current version"
+
+function jsonValue() {
+        KEY=$1
+        num=$2
+        awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/'$KEY'\042/){print $(i+1)}}}' | tr -d '"' | sed -n ${num}p
+}
+
+versiongit=$(curl -s -X GET https://api.github.com/repos/home-assistant/home-assistant/releases/latest | jsonValue tag_name 1|sed -e 's/^[[:space:]]*//')
+
+sudo -u homeassistant -H /bin/bash << EOF | grep Version|awk '{print $2'}|while read version; do if [[ ${versiongit} == ${version} ]]; then echo "You already have the latest version: $version";exit 1;fi;done
+source /srv/homeassistant/bin/activate
+pip3 show homeassistant
+EOF
+
+if [[ $? == 1 ]]; then
+        echo "Stopping upgrade"
+        exit 1
+fi
 
 echo "Stopping Home Assistant"
 systemctl stop home-assistant@homeassistant.service


### PR DESCRIPTION
Added a so that it skips upgrading if the version is already installed. If you want to be on the edge you can now crontab the upgrade or similar. Perhaps there is a better way, but this one seemed ok. Don't really need that json function but it might be handy for other stuff too.