### PR TITLE
DuckDNS: Added option to generate SSL certificate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ Before running this script you should already have an Duck DNS account, during t
 ```
 sudo hassbian-config install duckdns
 ```
+
+If you choose to aslo generate SSL certificates with this you would need to add this under `http:` to your `configuration.yaml`
+```
+  ssl_certificate: /home/homeassistant/dehydrated/certs/YOURDOMAIN.duckdns.org/fullchain.pem
+  ssl_key: /home/homeassistant/dehydrated/certs/YOURDOMAIN.duckdns.org/privkey.pem
+  base_url: YOURDOMAIN.duckdns.org:PORTNUMBER
+```
 This script was originally contributed by [@Ludeeus](https://github.com/Ludeeus).
 
 ### Install an web terminal for easy access to ssh in an web browser *(install_webterminal.sh)*

--- a/package/opt/hassbian/suites/files/ssl_hook.sh
+++ b/package/opt/hassbian/suites/files/ssl_hook.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+set -u
+set -o pipefail
+
+domain="myhome"
+token="your-duckdns-token"
+
+case "$1" in
+    "deploy_challenge")
+        curl "https://www.duckdns.org/update?domains=$domain&token=$token&txt=$4"
+        echo
+        ;;
+    "clean_challenge")
+        curl "https://www.duckdns.org/update?domains=$domain&token=$token&txt=removed&clear=true"
+        echo
+        ;;
+    "deploy_cert")
+        ;;
+    "unchanged_cert")
+        ;;
+    "startup_hook")
+        ;;
+    "exit_hook")
+        ;;
+    *)
+        echo Unknown hook "${1}"
+        exit 0
+        ;;
+esac

--- a/package/opt/hassbian/suites/install_duckdns.sh
+++ b/package/opt/hassbian/suites/install_duckdns.sh
@@ -45,8 +45,7 @@ if [ "$SSL_RESPONSE" == "y" ] || [ "$SSL_RESPONSE" == "Y" ]; then
 	echo $domain".duckdns.org" | tee domains.txt
 	echo "CHALLENGETYPE='dns-01'" | tee -a config
 	echo "HOOK='./hook.sh'" | tee -a config
-	#sudo curl -o ./hook.sh https://raw.githubusercontent.com/home-assistant/hassbian-scripts/dev/package/opt/hassbian/suites/files/ssl_hook.sh
-	cp /home/homeassistant/hook.sh /home/homeassistant/dehydrated/hook.sh
+	sudo curl -o ./hook.sh https://raw.githubusercontent.com/home-assistant/hassbian-scripts/dev/package/opt/hassbian/suites/files/ssl_hook.sh
 	sed -i 's/myhome/'$domain'/g' ./hook.sh
 	sed -i 's/your-duckdns-token/'$token'/g' ./hook.sh
 	chmod 755 hook.sh

--- a/package/opt/hassbian/suites/install_duckdns.sh
+++ b/package/opt/hassbian/suites/install_duckdns.sh
@@ -45,7 +45,7 @@ if [ "$SSL_RESPONSE" == "y" ] || [ "$SSL_RESPONSE" == "Y" ]; then
 	echo $domain".duckdns.org" | tee domains.txt
 	echo "CHALLENGETYPE='dns-01'" | tee -a config
 	echo "HOOK='./hook.sh'" | tee -a config
-	sudo curl -o ./hook.sh https://raw.githubusercontent.com/home-assistant/hassbian-scripts/dev/package/opt/hassbian/suites/files/ssl_hook.sh
+	curl -o ./hook.sh https://raw.githubusercontent.com/home-assistant/hassbian-scripts/dev/package/opt/hassbian/suites/files/ssl_hook.sh
 	sed -i 's/myhome/'$domain'/g' ./hook.sh
 	sed -i 's/your-duckdns-token/'$token'/g' ./hook.sh
 	chmod 755 hook.sh


### PR DESCRIPTION
This is an implementation this [https://www.splitbrain.org/blog/2017-08/10-homeassistant_duckdns_letsencrypt](https://www.splitbrain.org/blog/2017-08/10-homeassistant_duckdns_letsencrypt).  
For generating SSL Certificates, this methode also support auto-reneval.