### PR TITLE
Added line about appdaemon config folder to installer

### DIFF
--- a/package/opt/hassbian/suites/install_appdaemon.sh
+++ b/package/opt/hassbian/suites/install_appdaemon.sh
@@ -57,6 +57,8 @@ systemctl start appdaemon@homeassistant.service
 echo 
 echo "Installation done."
 echo
+echo "You may find the appdaemon configuration files in:"
+echo "/home/homeassistant/appdaemon"
 echo "To continue have a look at http://appdaemon.readthedocs.io/en/latest/"
 echo
 echo "If you have issues with this script, please say something in the #Hassbian channel on Discord."


### PR DESCRIPTION
Added a line to the post installation script for appdaemon. As a new user it took me longer than it should have to find where it was since the installer script didn't mention it anywhere. :)

Addition: "You may find the appdaemon configuration files in /home/homeassistant/appdaemon"