### PR TITLE
AppDaemon: Added option to expose config to samba.

### DIFF
--- a/package/opt/hassbian/suites/install_appdaemon.sh
+++ b/package/opt/hassbian/suites/install_appdaemon.sh
@@ -54,6 +54,24 @@ sync
 echo "Starting AppDaemon service"
 systemctl start appdaemon@homeassistant.service
 
+if [ -f "/usr/sbin/samba" ]; then
+	read -p "Do you want to add samba share for AppDaemon configuration? [N/y] : " SAMBA
+	if [ "$SAMBA" == "y" ] || [ "$SAMBA" == "Y" ]; then
+		echo "Adding configuration to samba..."
+		echo "[appdaemon]" | tee -a /etc/samba/smb.conf
+		echo "path = /home/homeassistant/appdaemon" | tee -a /etc/samba/smb.conf
+		echo "writeable = yes" | tee -a /etc/samba/smb.conf
+		echo "guest ok = yes" | tee -a /etc/samba/smb.conf
+		echo "create mask = 0644" | tee -a /etc/samba/smb.conf
+		echo "directory mask = 0755" | tee -a /etc/samba/smb.conf
+		echo "force user = homeassistant" | tee -a /etc/samba/smb.conf
+		echo "" | tee -a /etc/samba/smb.conf
+		echo "Restarting Samba service"
+		sudo systemctl restart smbd.service
+	fi
+fi
+
+
 echo 
 echo "Installation done."
 echo


### PR DESCRIPTION
This addition will look for samba, if found it will ask the user if AppDaemon configuration should be added as an samba share.
Default is (n/N).