### PR TITLE
LibCEC: Always use newest installed Python version.

### DIFF
--- a/package/opt/hassbian/suites/install_libcec.sh
+++ b/package/opt/hassbian/suites/install_libcec.sh
@@ -71,11 +71,8 @@ sudo ldconfig
 
 echo "Linking libcec to venv site packages"
 sudo -u homeassistant -H /bin/bash <<EOF
-if [ -d "/usr/lib/python3.5" ]; then
-   ln -s /usr/local/lib/python3.5/dist-packages/cec /srv/homeassistant/lib/python3.5/site-packages/
-   else
-   ln -s /usr/local/lib/python3.4/dist-packages/cec /srv/homeassistant/lib/python3.4/site-packages/
-fi
+PYTHONVER=$(ls /usr/local/lib/ | grep python | tail -1)
+ln -s /usr/local/lib/$PYTHONVER/dist-packages/cec /srv/homeassistant/lib/$PYTHONVER/site-packages/
 EOF
 
 echo

--- a/package/opt/hassbian/suites/install_libcec.sh
+++ b/package/opt/hassbian/suites/install_libcec.sh
@@ -70,8 +70,8 @@ sudo make install
 sudo ldconfig
 
 echo "Linking libcec to venv site packages"
-sudo -u homeassistant -H /bin/bash <<EOF
 PYTHONVER=$(ls /usr/local/lib/ | grep python | tail -1)
+sudo -u homeassistant -H /bin/bash <<EOF
 ln -s /usr/local/lib/$PYTHONVER/dist-packages/cec /srv/homeassistant/lib/$PYTHONVER/site-packages/
 EOF
 


### PR DESCRIPTION
Future proofing the installation script.