### PR TITLE
 Mosquitto: Workaround for stretch no longer needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ sudo hassbian-config install tradfri
 This script was originally contributed by [@Landrash](https://github.com/Landrash).
 
 ### Install Mosquitto *(install_mosquitto.sh)*
-**This script was broken since packages are not available for Debian Stretch, but we have implemented an workaround that make sure this will run as intended on HASSbian Stretch.** This script installs the MQTT Mosquitto server. Repository from the Mosquitto project is added to package system and the official packages for Debian are installed.
+This script installs the MQTT Mosquitto server. Repository from the Mosquitto project is added to package system and the official packages for Debian are installed.
 Additionally, this script helps you create your first MQTT user that can be used with Home Assistant.
 
 

--- a/package/opt/hassbian/suites/install_mosquitto.sh
+++ b/package/opt/hassbian/suites/install_mosquitto.sh
@@ -37,36 +37,19 @@ echo "Installing repository key"
 wget -O - http://repo.mosquitto.org/debian/mosquitto-repo.gpg.key | apt-key add -
 
 echo "Adding repository"
-cd /etc/apt/sources.list.d
-wget http://repo.mosquitto.org/debian/mosquitto-stretch.list
+OS_VERSION=$(cat /etc/os-release | grep VERSION= | awk -F'(' '{print $2}' |  awk -F')' '{print $1}')
+if [ ! -f /etc/apt/sources.list.d/mosquitto-$OS_VERSION.list ]
+then
+    sudo curl -o /etc/apt/sources.list.d/mosquitto-$OS_VERSION.list http://repo.mosquitto.org/debian/mosquitto-$OS_VERSION.list
+else
+	echo "Already present, skipping..."
+fi
+
 
 echo "Installing mosquitto"
 apt-get update
-apt install -y mosquitto mosquitto-clients
-
-
-if [[ $? > 0 ]]
-then
-   echo "First try failed, adding dependencies and trying again."
-   echo "This is an workaround and will be omited once it's fixed upstream."
-   echo "Downloading dependencies"
-   cd
-   wget http://ftp.se.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u7_armhf.deb
-   wget http://ftp.se.debian.org/debian/pool/main/libw/libwebsockets/libwebsockets3_1.2.2-1_armhf.deb
-
-   echo "Installing dependencies"
-   sudo dpkg -i libssl1.0.0_1.0.1t-1+deb8u7_armhf.deb
-   sudo dpkg -i libwebsockets3_1.2.2-1_armhf.deb
-
-   echo "Cleanup dependencies"
-   rm libssl1.0.0_1.0.1t-1+deb8u7_armhf.deb
-   rm libwebsockets3_1.2.2-1_armhf.deb
-   
-   echo "Retrying installation of mosquitto"
-   apt install -y mosquitto mosquitto-clients
-else
-    echo ""
-fi
+apt-cache search mosquitto
+apt-get install -y mosquitto mosquitto-clients
 
 echo "Writing default configuration"
 cd /etc/mosquitto
@@ -81,7 +64,6 @@ chmod 0600 pwfile
 
 echo
 echo "Please take a moment to setup your first MQTT user"
-echo "If no choice is made a default account will be created"
 echo
 
 echo -n "Username: "
@@ -101,20 +83,18 @@ echo "Creating password entry for user $mqtt_username"
 mosquitto_passwd -b pwfile "$mqtt_username" "$mqtt_password"
 
 echo "Restarting Mosquitto service"
-systemctl enable mosquitto.service
 systemctl restart mosquitto.service
 
-
-ip_address=$(ifconfig | awk -F':' '/inet addr/&&!/127.0.0.1/{split($2,_," ");print _[1]}')
+ip_address=$(ifconfig | grep "inet.*broadcast" | grep -v 0.0.0.0 | awk '{print $2}')
 
 echo
 echo "Installation done!"
 echo
-echo "Your MQTT broker is running at $ip_address:1883 or if prefered hassbian.local"
+echo "Your MQTT broker is running at $ip_address:1883 or if prefered hassbian.local:1883"
 echo
 echo "To continue have a look at https://home-assistant.io/docs/mqtt/"
 echo
-echo "If you have issues with this script, please say something in the #Hassbian channel on Discord."
+echo "If you have issues with this script, please say something in the #devs-hassbian channel on Discord."
 echo "Original script by @dale3h"
 echo
 return 0

--- a/package/opt/hassbian/suites/install_mosquitto.sh
+++ b/package/opt/hassbian/suites/install_mosquitto.sh
@@ -87,16 +87,26 @@ systemctl restart mosquitto.service
 
 ip_address=$(ifconfig | grep "inet.*broadcast" | grep -v 0.0.0.0 | awk '{print $2}')
 
-echo
-echo "Installation done!"
-echo
-echo "Your MQTT broker is running at $ip_address:1883 or if prefered hassbian.local:1883"
-echo
-echo "To continue have a look at https://home-assistant.io/docs/mqtt/"
-echo
-echo "If you have issues with this script, please say something in the #devs-hassbian channel on Discord."
-echo "Original script by @dale3h"
-echo
+echo "Checking the installation..."
+validation=$(ps -ef | grep -v grep | grep mosquitto | wc -l)
+if [ "$validation" != "0" ]; then
+	echo
+	echo -e "\e[32mInstallation done.\e[0m"
+	echo
+	echo "Your MQTT broker is running at $ip_address:1883 or if prefered hassbian.local:1883"
+	echo ""
+	echo "To continue have a look at https://home-assistant.io/docs/mqtt/"
+	echo "For more information see this repo:"
+	echo "https://github.com/home-assistant/homebridge-homeassistant#customization"
+	echo
+	echo "If you have issues with this script, please say something in the #devs_hassbian channel on Discord."
+	echo
+else
+	echo -e "\e[31mInstallation failed..."
+	echo -e "\e[31mAborting..."
+	echo -e "\e[0mIf you have issues with this script, please say something in the #devs_hassbian channel on Discord."
+	return 1
+fi
 return 0
 }
 


### PR DESCRIPTION
- Reverted back to original before stretch workaround.
- Should also now be back and forward compatible with older/newer versions of hassbian (if support in mosquitto repo.
- Does not create new list in `/etc/apt/sources.list.d` if one is already present.

- console log from installation: https://hastebin.com/ibuzufacaj.erl  
***

- [x]  Updated README.md
- [x] Script has validation check of the job.
- [x] Script is tested locally.