### PR TITLE
hassbian-config: Fixes tab-autocomplete.

### DIFF
--- a/package/etc/bash_completion.d/hassbian-config
+++ b/package/etc/bash_completion.d/hassbian-config
@@ -4,7 +4,7 @@ _hassbian-config()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="install upgrade show"
+    opts="install upgrade show log share-log"
 
     case "${prev}" in
         install|upgrade)

--- a/package/etc/bash_completion.d/hassbian-config
+++ b/package/etc/bash_completion.d/hassbian-config
@@ -4,17 +4,12 @@ _hassbian-config()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="install upgrade show log share-log"
+    opts="install upgrade show"
 
     case "${prev}" in
-        install)
-            local inst=$(find /opt/hassbian/suites/ -maxdepth 1 -type f -name 'install_*' | grep -v 'install_homeassistant.sh' | awk -F'/|_' ' {print $NF}' | awk -F. '{print $1}')
+        install|upgrade)
+            local inst=$(find /opt/hassbian/suites/ -maxdepth 1 -type f | awk -F'/|_' ' {print $NF}' | awk -F. '{print $1}')
             COMPREPLY=( $(compgen -W "${inst}" -- ${cur}) )
-            return 0
-            ;;
-        upgrade)
-            local upd=$(find /opt/hassbian/suites/ -maxdepth 1 -type f -name 'upgrade*' | awk -F'/|_' ' {print $NF}' | awk -F. '{print $1}')
-            COMPREPLY=( $(compgen -W "${upd}" -- ${cur}) )
             return 0
             ;;
         *)


### PR DESCRIPTION
This was broken by #90.
This correction will fix that.

- [ ]  ~Not applicable - Updated README.md~
- [ ] ~Not applicable - Script has validation check of the job.~
- [x] Script is tested locally.