### PR TITLE
hassbian-config: Better handling of missing upgrade scripts.

### DIFF
--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -103,6 +103,13 @@ function install-suite {
 
 function upgrade-suite {
    # Having got here, the installer script exists; source it, then run the installer function.
+   UPGRADE=$(cat $SUITE_INSTALL_DIR/$1.sh | grep $1-upgrade-package)
+     if [ "$UPGRADE" == "" ]; then
+       echo "Upgrade script is not available..."
+       echo "You can force run the install script like this:"
+       echo "sudo hassbian-config -f install $1"
+       exit
+     fi
    check-permission
    source $SUITE_INSTALL_DIR/$1.sh
    $1-upgrade-package


### PR DESCRIPTION
The message presented if trying to upgrade a suite where there is no upgrade function is not pretty..
This PR will change the message form:
![image](https://user-images.githubusercontent.com/15093472/35885697-fe122672-0b8e-11e8-8b38-f3498d376e4b.png)
to:
![image](https://user-images.githubusercontent.com/15093472/35885707-064287a6-0b8f-11e8-8e42-9c1fe1906de4.png)
- [ ]  ~Not applicable - Updated README.md~
- [ ] ~Not applicable - Script has validation check of the job.~
- [x] Script is tested locally.