### PR TITLE
Hassbian: Fixes install problem at Hassbian boot.

### DIFF
--- a/package/etc/systemd/system/install_homeassistant.service
+++ b/package/etc/systemd/system/install_homeassistant.service
@@ -7,7 +7,7 @@ Description=Install Home Assistant
 After=network.target
 
 [Service]
-ExecStart=/opt/hassbian/suites/install_homeassistant.sh
+ExecStart=/usr/local/bin/hassbian-config install homeassistant
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This also was introduced in the change in #90 :(
I could have just removed "install_" from the string and it would have worked, but the we get some nice advantages by doing it this way.

First it will create an control file, so if someone run `sudo hassbian-config install homeassistant` it will redirect to the upgrade script.

Second it will create an log of the operation in case something goes wrong it can be inspected by running `hassbian-config log` or shared by running `hassbian-config share-log`

- [ ]  ~Not applicable - Updated README.md~
- [ ] ~Not applicable - Script has validation check of the job.~
- [x] Script is tested locally.