### PR TITLE
DuckDNS: Add support for typing the full domain.

### DIFF
--- a/package/opt/hassbian/suites/duckdns.sh
+++ b/package/opt/hassbian/suites/duckdns.sh
@@ -29,6 +29,10 @@ fi
 if [[ $domain = *"duckdns"* ]]; then
   domain=$(echo "$domain" | cut -d\. -f1)
 fi
+if [[ $domain = *"//"* ]]; then
+  domain=$(echo "$domain" | cut -d\/ -f3)
+fi
+
 
 echo -n "Token: "
 read token

--- a/package/opt/hassbian/suites/duckdns.sh
+++ b/package/opt/hassbian/suites/duckdns.sh
@@ -26,6 +26,9 @@ read domain
 if [ ! "$domain" ]; then
   exit
 fi
+if [[ $domain = *"duckdns"* ]]; then
+  domain=$(echo "$domain" | cut -d\. -f1)
+fi
 
 echo -n "Token: "
 read token


### PR DESCRIPTION
This will allow users to type the domain in various ways:
- example
- example.duckdns.org
- example.duckdns.org:8123
- http://example.duckdns.org
- http://example.duckdns.org:8123
And it will always use `example` in the rest of the script.

***
- [ ] ~Created/Updated documentation at /docs/~
- [ ] ~Script has validation check of the job.~
- [X] Script is tested locally.