### PR TITLE
Hassbian-config: Add log to upgrade function.

### DIFF
--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -120,7 +120,7 @@ function upgrade-suite {
   fi
   check-permission
   source $SUITE_INSTALL_DIR/"$1".sh
-  "$1"-upgrade-package
+  "$1"-upgrade-package | tee $LOGFILE
   return 0
 }
 


### PR DESCRIPTION
### Description:
Write to log was missing from the upgrade function.
This will correct that.
**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

### Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Script has validation check of the job.
  
#### If pertinent:
  - [ ] Created/Updated documentation at `/docs`
  
