### PR TITLE
Fix typo shown in hassbian-upgrade

### DIFF
--- a/package/opt/hassbian/suites/homeassistant.sh
+++ b/package/opt/hassbian/suites/homeassistant.sh
@@ -96,7 +96,7 @@ echo "Restarting Home Assistant"
 systemctl start home-assistant@homeassistant.service
 
 echo
-echo "Uppgrade complete."
+echo "Upgrade complete."
 echo
 echo "Note that it may take some time to start up after an upgrade."
 echo


### PR DESCRIPTION
Fix typo of word "upgrade"

### Description:

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

### Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Script has validation check of the job.
  
#### If pertinent:
  - [ ] Created/Updated documentation at `/docs`
  
