### PR TITLE
hassbian-config: Usage cleanup, added new help and command options.

### DIFF
--- a/docs/hassbian_config.md
+++ b/docs/hassbian_config.md
@@ -12,11 +12,14 @@ where command is one of:
 - `show` This will show you all available suites.
 - `log` This will show you the log of last hassbian-config operation.
 - `share-log` This will generate an hastebin link of the last hassbian-config operation.
-- `-V` This will show you the installed version of `hassbian-config`.
 
 Optional flags:
-- `-y` This will accept defaults on scripts that allow this.
-- `-f` This will force run an script. This is useful if you need to reinstall a package.
+- `-y | --accept` This will accept defaults on scripts that allow this.
+- `-f | --force` This will force run an script. This is useful if you need to reinstall a package.
+
+Other available comands:
+- `-V | --version` This will show you the installed version of `hassbian-config`.
+- `-H | --help` Shows help for the tool, with all available commands.
 
 ## Installation
 This package is pre-installed on the [Hassbian image](https://github.com/home-assistant/pi-gen/releases).

--- a/package/opt/hassbian/suites/libcec.sh
+++ b/package/opt/hassbian/suites/libcec.sh
@@ -16,11 +16,6 @@ function libcec-install-package {
 libcec-show-short-info
 libcec-show-copyright-info
 
-if [ "$(id -u)" != "0" ]; then
-  echo "This script must be run with sudo. Use \"sudo ${0} ${*}\"" 1>&2
-  return 1
-fi
-
 echo "Running apt-get preparation"
 apt-get update
 apt-get install -y cmake libudev-dev libxrandr-dev swig

--- a/package/opt/hassbian/suites/mariadb.sh
+++ b/package/opt/hassbian/suites/mariadb.sh
@@ -16,11 +16,6 @@ function mariadb-install-package {
 mariadb-show-short-info
 mariadb-show-copyright-info
 
-if [ "$(id -u)" != "0" ]; then
-  echo "This script must be run with sudo. Use \"sudo ${0} ${*}\"" 1>&2
-  return 1
-fi
-
 echo "Running apt-get preparation"
 apt-get update
 apt-get install -y mariadb-server libmariadbclient-dev

--- a/package/opt/hassbian/suites/mosquitto.sh
+++ b/package/opt/hassbian/suites/mosquitto.sh
@@ -17,11 +17,6 @@ function mosquitto-install-package {
 mosquitto-show-short-info
 mosquitto-show-copyright-info
 
-if [ "$(id -u)" != "0" ]; then
-echo "This script must be run with sudo. Use \"sudo ${0} ${*}\"" 1>&2
-return 1
-fi
-
 if [ "$ACCEPT" == "true" ]; then
   mqtt_username=pi
   mqtt_password=raspberry

--- a/package/opt/hassbian/suites/mssql.sh
+++ b/package/opt/hassbian/suites/mssql.sh
@@ -16,11 +16,6 @@ function mssql-install-package {
 mssql-show-short-info
 mssql-show-copyright-info
 
-if [ "$(id -u)" != "0" ]; then
-  echo "This script must be run with sudo. Use \"sudo ${0} ${*}\"" 1>&2
-  return 1
-fi
-
 echo "Running apt-get preparation"
 apt-get update
 apt-get install -y freetds-dev

--- a/package/opt/hassbian/suites/mysql.sh
+++ b/package/opt/hassbian/suites/mysql.sh
@@ -16,11 +16,6 @@ function mysql-install-package {
 mysql-show-short-info
 mysql-show-copyright-info
 
-if [ "$(id -u)" != "0" ]; then
-  echo "This script must be run with sudo. Use \"sudo ${0} ${*}\"" 1>&2
-  return 1
-fi
-
 echo "Running apt-get preparation"
 apt-get update
 apt-get install -y default-libmysqlclient-dev libssl-dev

--- a/package/opt/hassbian/suites/postgresql.sh
+++ b/package/opt/hassbian/suites/postgresql.sh
@@ -16,11 +16,6 @@ function postgresql-install-package {
 postgresql-show-short-info
 postgresql-show-copyright-info
 
-if [ "$(id -u)" != "0" ]; then
-  echo "This script must be run with sudo. Use \"sudo ${0} ${*}\"" 1>&2
-  return 1
-fi
-
 echo "Running apt-get preparation"
 apt-get update
 apt-get install -y postgresql-server-dev-9.6 postgresql-9.6

--- a/package/opt/hassbian/suites/samba.sh
+++ b/package/opt/hassbian/suites/samba.sh
@@ -17,11 +17,6 @@ function samba-install-package {
 samba-show-short-info
 samba-show-copyright-info
 
-if [ "$(id -u)" != "0" ]; then
-  echo "This script must be run with sudo. Use \"sudo ${0} ${*}\"" 1>&2
-  return 1
-fi
-
 echo "Running apt-get preparation"
 apt-get update
 apt-get install -y samba

--- a/package/opt/hassbian/suites/tradfri.sh
+++ b/package/opt/hassbian/suites/tradfri.sh
@@ -16,11 +16,6 @@ function tradfri-install-package {
 tradfri-show-short-info
 tradfri-show-copyright-info
 
-if [ "$(id -u)" != "0" ]; then
-   echo "This script must be run with sudo. Use \"sudo ${0} ${*}\"" 1>&2
-   return 1
-fi
-
 echo "Running apt-get preparation"
 apt-get update
 apt-get install -y dh-autoreconf

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -98,7 +98,7 @@ function share-log {
 
 function install-suite {
   if [ "$(id -u)" != "0" ]; then
-    echo "This script must be run with sudo. Use 'sudo hassbian-config install "$1"'" 1>&2
+    echo "This script must be run with sudo. Use 'sudo hassbian-config install $1'" 1>&2
     return 1
   fi
   if [ ! -f $SUITE_CONTROL_DIR/"$1" ]; then
@@ -131,7 +131,7 @@ function install-suite {
 
 function upgrade-suite {
   if [ "$(id -u)" != "0" ]; then
-    echo "This script must be run with sudo. Use 'sudo hassbian-config upgrade "$1"'" 1>&2
+    echo "This script must be run with sudo. Use 'sudo hassbian-config upgrade $1'" 1>&2
     return 1
   fi
   UPGRADE=$(grep "$1"-upgrade-package $SUITE_INSTALL_DIR/"$1".sh)

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -4,17 +4,22 @@ SUITE_INSTALL_DIR=/opt/hassbian/suites
 SUITE_CONTROL_DIR=/srv/homeassistant/hassbian/control
 
 function usage {
-  echo hassbian-config usage:
-  echo
-  echo hassbian-config \<command\> \<suite\>
-  echo where \<command\> is one of:
-  echo     install   - installs a software suite
-  echo     upgrade   - upgrades a software suite
-  echo     show      - shows software suites available
-  echo     log       - displays an log of the last operation
-  echo     share-log - generates an hastebin link of the last operation
-  echo and \<suite\> is the name of a software component to operate on.
-  echo
+  printf "hassbian-config\\n"
+  printf "Version: $(hassbian-config -V)\\n"
+  printf "\\n"
+  printf "usage: hassbian-config [command] [suite] [options]\\n"
+  printf "where [command] is one of:\\n"
+  printf "%-8s\\t%s\\n" "  install" "Installs a software [suite]"
+  printf "%-8s\\t%s\\n" "  upgrade" "Upgrades a software [suite]"
+  printf "%-8s\\t%s\\n" "  show" "To see available [suite] for isntall/upgrade"
+  printf "%-8s\\t%s\\n" "  log" "Displays an log of the last operation"
+  printf "%-8s\\t%s\\n" "  share-log" "Generates an hastebin link of the last operation"
+  printf "%-8s\\t%s\\n" "  -V" "Prints the version of hassbian-config"
+  printf "\\n"
+  printf "available [options]:\\n"
+  printf "%-5s\\t%s\\n" "  -y" "accept all inputs/defaults"
+  printf "%-5s\\t%s\\n" "  -f" "force"
+  printf "\\n"
   return 0
 }
 

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -4,6 +4,11 @@ SUITE_INSTALL_DIR=/opt/hassbian/suites
 SUITE_CONTROL_DIR=/srv/homeassistant/hassbian/control
 
 function usage {
+  printf "usage: hassbian-config [command] [suite] [options]\\n"
+  return 0
+}
+
+function help {
   printf "hassbian-config\\n"
   printf "%s\\n" "version: $(hassbian-config -V)"
   printf "\\n"
@@ -11,14 +16,17 @@ function usage {
   printf "where [command] is one of:\\n"
   printf "%-8s\\t%s\\n" "  install" "Installs a software [suite]"
   printf "%-8s\\t%s\\n" "  upgrade" "Upgrades a software [suite]"
-  printf "%-8s\\t%s\\n" "  show" "To see available [suite] for isntall/upgrade"
+  printf "%-8s\\t%s\\n" "  show" "To see available [suite] for install/upgrade"
   printf "%-8s\\t%s\\n" "  log" "Displays an log of the last operation"
   printf "%-8s\\t%s\\n" "  share-log" "Generates an hastebin link of the last operation"
-  printf "%-8s\\t%s\\n" "  -V" "Prints the version of hassbian-config"
   printf "\\n"
   printf "available optional [options]:\\n"
-  printf "%-5s\\t%s\\n" "  -y" "accept defaults on scripts that allow this"
-  printf "%-5s\\t%s\\n" "  -f" "force run an script, this is useful if you need to reinstall a package"
+  printf "%-10s\\t%s\\n" " -y | --accept" "Accept defaults on scripts that allow this"
+  printf "%-10s\\t%s\\n" " -f | --force" "Force run an script, this is useful if you need to reinstall a package"
+  printf "\\n"
+  printf "other [command] available:\\n"
+  printf "%-10s\\t%s\\n" " -V | --version" "Prints the version of hassbian-config"
+  printf "%-10s\\t%s\\n" " -H | --help" "Shows this help"
   printf "\\n"
   return 0
 }
@@ -88,6 +96,10 @@ function share-log {
 }
 
 function install-suite {
+  if [ "$(id -u)" != "0" ]; then
+    echo "This script must be run with sudo. Use \"sudo hassbian-config install "$1"\"" 1>&2
+    return 1
+  fi
   if [ ! -f $SUITE_CONTROL_DIR/"$1" ]; then
     touch $SUITE_CONTROL_DIR/"$1"
     echo "SCRIPTSTATE=uninstalled" > $SUITE_CONTROL_DIR/"$1"
@@ -117,6 +129,10 @@ function install-suite {
 }
 
 function upgrade-suite {
+  if [ "$(id -u)" != "0" ]; then
+    echo "This script must be run with sudo. Use \"sudo hassbian-config upgrade "$1"\"" 1>&2
+    return 1
+  fi
   UPGRADE=$(grep "$1"-upgrade-package $SUITE_INSTALL_DIR/"$1".sh)
   if [ "$UPGRADE" == "" ]; then
     echo "Upgrade script is not available..."
@@ -164,11 +180,11 @@ SUITE=$2
 
 
 case $COMMAND in
-  "-f")
+  "-f"|"--force")
     FORCE="true"
     shift # past argument
     ;;
-  "-y")
+  "-y"|"--accept")
     ACCEPT="true"
     shift # past argument
     ;;
@@ -211,13 +227,17 @@ case $COMMAND in
     RUN="share-log"
     shift # past argument
     ;;
-  "-V")
+  "-V"|"--version")
     VERSION=$(dpkg -s hassbian-scripts | grep 'Version:' | awk '{print $2}')
     RUN="echo $VERSION"
     shift # past argument
     ;;
   "show-installed")
     RUN="show-installed-suites"
+    shift # past argument
+    ;;
+  "-H"|"--help")
+    RUN="help"
     shift # past argument
     ;;
   *)

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -5,6 +5,7 @@ SUITE_CONTROL_DIR=/srv/homeassistant/hassbian/control
 
 function usage {
   printf "usage: hassbian-config [command] [suite] [options]\\n"
+  printf "run 'hassbian-config --help' to see all options\\n"
   return 0
 }
 

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -5,7 +5,7 @@ SUITE_CONTROL_DIR=/srv/homeassistant/hassbian/control
 
 function usage {
   printf "hassbian-config\\n"
-  printf "Version: $(hassbian-config -V)\\n"
+  printf "%s\\n" "version: $(hassbian-config -V)"
   printf "\\n"
   printf "usage: hassbian-config [command] [suite] [options]\\n"
   printf "where [command] is one of:\\n"
@@ -16,9 +16,9 @@ function usage {
   printf "%-8s\\t%s\\n" "  share-log" "Generates an hastebin link of the last operation"
   printf "%-8s\\t%s\\n" "  -V" "Prints the version of hassbian-config"
   printf "\\n"
-  printf "available [options]:\\n"
-  printf "%-5s\\t%s\\n" "  -y" "accept all inputs/defaults"
-  printf "%-5s\\t%s\\n" "  -f" "force"
+  printf "available optional [options]:\\n"
+  printf "%-5s\\t%s\\n" "  -y" "accept defaults on scripts that allow this"
+  printf "%-5s\\t%s\\n" "  -f" "force run an script, this is useful if you need to reinstall a package"
   printf "\\n"
   return 0
 }

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -98,7 +98,7 @@ function share-log {
 
 function install-suite {
   if [ "$(id -u)" != "0" ]; then
-    echo "This script must be run with sudo. Use \"sudo hassbian-config install "$1"\"" 1>&2
+    echo "This script must be run with sudo. Use 'sudo hassbian-config install "$1"'" 1>&2
     return 1
   fi
   if [ ! -f $SUITE_CONTROL_DIR/"$1" ]; then
@@ -131,7 +131,7 @@ function install-suite {
 
 function upgrade-suite {
   if [ "$(id -u)" != "0" ]; then
-    echo "This script must be run with sudo. Use \"sudo hassbian-config upgrade "$1"\"" 1>&2
+    echo "This script must be run with sudo. Use 'sudo hassbian-config upgrade "$1"'" 1>&2
     return 1
   fi
   UPGRADE=$(grep "$1"-upgrade-package $SUITE_INSTALL_DIR/"$1".sh)


### PR DESCRIPTION
### Description:
 - usage (if hassbian-config is used wrong) now only prints two lines.
 - Added new help function (rewrite of the old usage function).
 - Added sudo check to install and upgrade function.
 - Removed sudo check inside suite scripts.
 - Added new commands:
    - `-H` and `--help` to show the help menu.
    - `--version`, as alias to `-V`
    - `--force` as alias to `-f`
    - `--accept` as alias to `-y`

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

### Checklist:
  - [X] The code change is tested and works locally.
  
#### If pertinent:
  - [X] Created/Updated documentation at `/docs`
  
Screenshot of the help function:
![image](https://user-images.githubusercontent.com/15093472/36632059-988d14a0-1981-11e8-9b0d-adab99b933ec.png)
