### PR TITLE
Webterminal: Added SSL support with existing LE certificates.

### DIFF
--- a/docs/webterminal.md
+++ b/docs/webterminal.md
@@ -31,7 +31,7 @@ panel_iframe:
 #### Notes for SSL
 If you enable the use of existing Let's Encrypt certificates you need to open ports in your firewall to use them.
 
-If SSL is used the panel_iframe has to use your domain.
+If SSL is used the panel_iframe has to use the same domain name as the one issued with your certificate.
 ```yaml
 panel_iframe:
   web_terminal:

--- a/docs/webterminal.md
+++ b/docs/webterminal.md
@@ -27,5 +27,17 @@ panel_iframe:
     icon: mdi:console
     url: 'http://192.168.1.2:4200'
 ```
+
+#### Notes for SSL
+If you enable the use of existing Let's Encrypt certificates you need to open ports in your firewall to use them.
+
+If SSL is used the panel_iframe has to use your domain.
+```yaml
+panel_iframe:
+  web_terminal:
+    title: 'Web terminal'
+    icon: mdi:console
+    url: 'https://yourdomain.duckdns.org:4200'
+```
 ***
 This script was originally contributed by [@Ludeeus](https://github.com/ludeeus).

--- a/package/opt/hassbian/suites/files/webterminalsslhelper.sh
+++ b/package/opt/hassbian/suites/files/webterminalsslhelper.sh
@@ -10,7 +10,7 @@ fi
 FULLCHAIN=$(find "$CERTDIR" -type f | grep fullchain)
 PRIVKEY=$(find "$CERTDIR" -type f | grep privkey)
 DOMAIN=$(ls "$CERTDIR")
-cat $FULLCHAIN $PRIVKEY > /var/lib/shellinabox/certificate-"$DOMAIN".pem
+cat "$FULLCHAIN" "$PRIVKEY" > /var/lib/shellinabox/certificate-"$DOMAIN".pem
 chown shellinabox:shellinabox -R /var/lib/shellinabox/
 service shellinabox restart
 exit 0

--- a/package/opt/hassbian/suites/files/webterminalsslhelper.sh
+++ b/package/opt/hassbian/suites/files/webterminalsslhelper.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Helper script for using LE certificates with Webterminal (shellinabox)
+if [ -d "/etc/letsencrypt/live" ]; then
+  CERTDIR="/etc/letsencrypt/live/"
+elif [ -d "/home/homeassistant/dehydrated/certs" ]; then
+  CERTDIR="/home/homeassistant/dehydrated/certs/"
+else
+  CERTDIR=""
+fi
+FULLCHAIN=$(find "$CERTDIR" -type f | grep fullchain)
+PRIVKEY=$(find "$CERTDIR" -type f | grep privkey)
+DOMAIN=$(ls "$CERTDIR")
+cat $FULLCHAIN $PRIVKEY > /var/lib/shellinabox/certificate-"$DOMAIN".pem
+chown shellinabox:shellinabox -R /var/lib/shellinabox/
+service shellinabox restart
+exit 0

--- a/package/opt/hassbian/suites/files/webterminalsslhelper.sh
+++ b/package/opt/hassbian/suites/files/webterminalsslhelper.sh
@@ -7,10 +7,8 @@ elif [ -d "/home/homeassistant/dehydrated/certs" ]; then
 else
   CERTDIR=""
 fi
-FULLCHAIN=$(find "$CERTDIR" -type f | grep fullchain)
-PRIVKEY=$(find "$CERTDIR" -type f | grep privkey)
 DOMAIN=$(ls "$CERTDIR")
-cat "$FULLCHAIN" "$PRIVKEY" > /var/lib/shellinabox/certificate-"$DOMAIN".pem
+cat "$CERTDIR$DOMAIN/fullchain.pem" "$CERTDIR$DOMAIN/privkey.pem" > /var/lib/shellinabox/certificate-"$DOMAIN".pem
 chown shellinabox:shellinabox -R /var/lib/shellinabox/
 service shellinabox restart
 exit 0

--- a/package/opt/hassbian/suites/files/webterminalsslhelper.sh
+++ b/package/opt/hassbian/suites/files/webterminalsslhelper.sh
@@ -10,5 +10,7 @@ fi
 DOMAIN=$(ls "$CERTDIR")
 cat "$CERTDIR$DOMAIN/fullchain.pem" "$CERTDIR$DOMAIN/privkey.pem" > /var/lib/shellinabox/certificate-"$DOMAIN".pem
 chown shellinabox:shellinabox -R /var/lib/shellinabox/
-service shellinabox restart
+service shellinabox reload
+service shellinabox stop
+service shellinabox start
 exit 0

--- a/package/opt/hassbian/suites/webterminal.sh
+++ b/package/opt/hassbian/suites/webterminal.sh
@@ -40,13 +40,9 @@ if [ "$SSL" == "y" ] || [ "$SSL" == "Y" ]; then
   else
     CERTDIR=""
   fi
-  echo "Setting cert fullchain location..."
-  FULLCHAIN=$(find "$CERTDIR" -type f | grep fullchain)
-  echo "Setting cert privkey location..."
-  PRIVKEY=$(find "$CERTDIR" -type f | grep privkey)
-  DOMAIN=$(ls "$CERTDIR")
   echo "Merging files and adding to correct dir..."
-  cat "$FULLCHAIN" "$PRIVKEY" > /var/lib/shellinabox/certificate-"$DOMAIN".pem
+  DOMAIN=$(ls "$CERTDIR")
+  cat "$CERTDIR$DOMAIN/fullchain.pem" "$CERTDIR$DOMAIN/privkey.pem" > /var/lib/shellinabox/certificate-"$DOMAIN".pem
   chown shellinabox:shellinabox -R /var/lib/shellinabox/
   echo "Adding crong job to copy certs..."
   (crontab -l ; echo "5 1 1 * * bash /opt/hassbian/suites/files/webterminalsslhelper.sh >/dev/null 2>&1")| crontab -

--- a/package/opt/hassbian/suites/webterminal.sh
+++ b/package/opt/hassbian/suites/webterminal.sh
@@ -12,8 +12,6 @@ function webterminal-show-copyright-info {
 }
 
 function webterminal-install-package {
-
-
 if [ "$ACCEPT" == "true" ]; then # True if `-y` flag is used.
   if [ -d "/etc/letsencrypt/live" ] || [ -d "/home/homeassistant/dehydrated/certs" ]; then
     SSL="Y"
@@ -62,13 +60,19 @@ service shellinabox restart
 
 ip_address=$(ifconfig | grep "inet.*broadcast" | grep -v 0.0.0.0 | awk '{print $2}')
 
+if [ "$SSL" == "y" ] || [ "$SSL" == "Y" ]; then
+  PROTOCOL="https"
+else
+  PROTOCOL="http"
+fi
+
 echo "Checking the installation..."
 validation=$(pgrep -f shellinaboxd)
 if [ ! -z "${validation}" ]; then
   echo
   echo -e "\\e[32mInstallation done..\\e[0m"
   echo
-  echo "You can now access the web terminal here: http://$ip_address:4200"
+  echo "You can now access the web terminal here: $PROTOCOL://$ip_address:4200"
   echo "You can also add this to your Home-Assistant config in an 'panel_iframe'"
   echo
 else

--- a/package/opt/hassbian/suites/webterminal.sh
+++ b/package/opt/hassbian/suites/webterminal.sh
@@ -48,7 +48,7 @@ if [ "$SSL" == "y" ] || [ "$SSL" == "Y" ]; then
   PRIVKEY=$(find "$CERTDIR" -type f | grep privkey)
   DOMAIN=$(ls "$CERTDIR")
   echo "Merging files and adding to correct dir..."
-  cat $FULLCHAIN $PRIVKEY > /var/lib/shellinabox/certificate-"$DOMAIN".pem
+  cat "$FULLCHAIN" "$PRIVKEY" > /var/lib/shellinabox/certificate-"$DOMAIN".pem
   chown shellinabox:shellinabox -R /var/lib/shellinabox/
   echo "Adding crong job to copy certs..."
   (crontab -l ; echo "0 1 1 * * bash /opt/hassbian/suites/files/webterminalsslhelper.sh")| crontab -

--- a/package/opt/hassbian/suites/webterminal.sh
+++ b/package/opt/hassbian/suites/webterminal.sh
@@ -49,7 +49,7 @@ if [ "$SSL" == "y" ] || [ "$SSL" == "Y" ]; then
   cat "$FULLCHAIN" "$PRIVKEY" > /var/lib/shellinabox/certificate-"$DOMAIN".pem
   chown shellinabox:shellinabox -R /var/lib/shellinabox/
   echo "Adding crong job to copy certs..."
-  (crontab -l ; echo "0 1 1 * * bash /opt/hassbian/suites/files/webterminalsslhelper.sh")| crontab -
+  (crontab -l ; echo "0 1 1 * * bash /opt/hassbian/suites/files/webterminalsslhelper.sh >/dev/null 2>&1")| crontab -
 else
   sed -i 's/--no-beep/--no-beep --disable-ssl/g' /etc/default/shellinabox
 fi

--- a/package/opt/hassbian/suites/webterminal.sh
+++ b/package/opt/hassbian/suites/webterminal.sh
@@ -52,7 +52,8 @@ fi
 
 echo "Reloading and starting the service."
 service shellinabox reload
-service shellinabox restart
+service shellinabox stop
+service shellinabox start
 
 ip_address=$(ifconfig | grep "inet.*broadcast" | grep -v 0.0.0.0 | awk '{print $2}')
 

--- a/package/opt/hassbian/suites/webterminal.sh
+++ b/package/opt/hassbian/suites/webterminal.sh
@@ -49,7 +49,7 @@ if [ "$SSL" == "y" ] || [ "$SSL" == "Y" ]; then
   cat "$FULLCHAIN" "$PRIVKEY" > /var/lib/shellinabox/certificate-"$DOMAIN".pem
   chown shellinabox:shellinabox -R /var/lib/shellinabox/
   echo "Adding crong job to copy certs..."
-  (crontab -l ; echo "0 1 1 * * bash /opt/hassbian/suites/files/webterminalsslhelper.sh >/dev/null 2>&1")| crontab -
+  (crontab -l ; echo "5 1 1 * * bash /opt/hassbian/suites/files/webterminalsslhelper.sh >/dev/null 2>&1")| crontab -
 else
   sed -i 's/--no-beep/--no-beep --disable-ssl/g' /etc/default/shellinabox
 fi


### PR DESCRIPTION
## Description:
This add the option to use existing Let's Encrypt certificates.

Tested with:
- [X] Generated with Dehydrated. (DuckDNS script) tested by @ludeeus
- [X] Generated with certbot. _Simulated testing bt @ludeeus, se comment, this should work._

**Related issue (if applicable):** Fixes #74 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Script has validation check of the job.
  
### If pertinent:
  - [X] Created/Updated documentation at `/docs`
  
![image](https://user-images.githubusercontent.com/15093472/36945814-b0e96638-1fb3-11e8-974e-e6096691069b.png)
