### PR TITLE
Hassbian-config: Added debug option.

### DIFF
--- a/docs/hassbian_config.md
+++ b/docs/hassbian_config.md
@@ -16,6 +16,7 @@ where command is one of:
 Optional flags:
 - `-y | --accept` This will accept defaults on scripts that allow this.
 - `-f | --force` This will force run an script. This is useful if you need to reinstall a package.
+- `-D | --debug` This will output every comand to the console.
 
 Other available comands:
 - `-V | --version` This will show you the installed version of `hassbian-config`.

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -24,6 +24,7 @@ function help {
   printf "available optional [options]:\\n"
   printf "%-10s\\t%s\\n" " -y | --accept" "Accept defaults on scripts that allow this"
   printf "%-10s\\t%s\\n" " -f | --force" "Force run an script, this is useful if you need to reinstall a package"
+  printf "%-10s\\t%s\\n" " -D | --debug" "This will output every comand to the console."
   printf "\\n"
   printf "other [command] available:\\n"
   printf "%-10s\\t%s\\n" " -V | --version" "Prints the version of hassbian-config"
@@ -96,6 +97,28 @@ function share-log {
   return 0
 }
 
+function run-installer {
+  source $SUITE_INSTALL_DIR/"$1".sh
+  if [ "$DEBUG" == "true" ]; then
+    set -x
+    "$1"-install-package | tee $LOGFILE
+    set +x
+  else
+    "$1"-install-package | tee $LOGFILE
+  fi
+}
+
+function run-upgrader {
+  source $SUITE_INSTALL_DIR/"$1".sh
+  if [ "$DEBUG" == "true" ]; then
+    set -x
+    "$1"-upgrade-package | tee $LOGFILE
+    set +x
+  else
+    "$1"-upgrade-package | tee $LOGFILE
+  fi
+}
+
 function install-suite {
   if [ "$(id -u)" != "0" ]; then
     echo "This script must be run with sudo. Use 'sudo hassbian-config install $1'" 1>&2
@@ -106,9 +129,8 @@ function install-suite {
     echo "SCRIPTSTATE=uninstalled" > $SUITE_CONTROL_DIR/"$1"
   fi
     SUITESTATE=$(grep "SCRIPTSTATE" $SUITE_CONTROL_DIR/"$1" | awk -F'=' '{print $2}')
-    source $SUITE_INSTALL_DIR/"$1".sh
   if [ "$FORCE" == "true" ]; then
-    "$1"-install-package | tee $LOGFILE
+    run-installer "$1"
     sed -i -- 's/SCRIPTSTATE='"$SUITESTATE"'/SCRIPTSTATE=installed/g' $SUITE_CONTROL_DIR/"$1"
   elif [ "$SUITESTATE" == "installed" ]; then
     echo "$1 is already installed, trying upgrade script..."
@@ -119,11 +141,10 @@ function install-suite {
     echo "sudo hassbian-config -f install $1"
     exit
   fi
-    "$1"-upgrade-package | tee $LOGFILE
+    run-upgrader "$1"
     sed -i -- 's/SCRIPTSTATE='"$SUITESTATE"'/SCRIPTSTATE=installed/g' $SUITE_CONTROL_DIR/"$1"
   else
-    source $SUITE_INSTALL_DIR/"$1".sh
-    "$1"-install-package | tee $LOGFILE
+
     sed -i -- 's/SCRIPTSTATE='"$SUITESTATE"'/SCRIPTSTATE=installed/g' $SUITE_CONTROL_DIR/"$1"
   fi
   return 0
@@ -141,8 +162,7 @@ function upgrade-suite {
     echo "sudo hassbian-config -f install $1"
   fi
   check-permission
-  source $SUITE_INSTALL_DIR/"$1".sh
-  "$1"-upgrade-package | tee $LOGFILE
+  run-upgrader "$1"
   return 0
 }
 
@@ -187,6 +207,10 @@ case $COMMAND in
     ;;
   "-y"|"--accept")
     ACCEPT="true"
+    shift # past argument
+    ;;
+  "-D"|"--debug")
+    DEBUG="true"
     shift # past argument
     ;;
   "show")

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -97,40 +97,22 @@ function share-log {
   return 0
 }
 
-function run-installer {
-  source $SUITE_INSTALL_DIR/"$1".sh
-  if [ "$DEBUG" == "true" ]; then
-    set -x
-    "$1"-install-package | tee $LOGFILE
-    set +x
-  else
-    "$1"-install-package | tee $LOGFILE
-  fi
-}
-
-function run-upgrader {
-  source $SUITE_INSTALL_DIR/"$1".sh
-  if [ "$DEBUG" == "true" ]; then
-    set -x
-    "$1"-upgrade-package | tee $LOGFILE
-    set +x
-  else
-    "$1"-upgrade-package | tee $LOGFILE
-  fi
-}
-
 function install-suite {
   if [ "$(id -u)" != "0" ]; then
     echo "This script must be run with sudo. Use 'sudo hassbian-config install $1'" 1>&2
     return 1
+  fi
+  if [ "$DEBUG" == "true" ]; then
+    set -x
   fi
   if [ ! -f $SUITE_CONTROL_DIR/"$1" ]; then
     touch $SUITE_CONTROL_DIR/"$1"
     echo "SCRIPTSTATE=uninstalled" > $SUITE_CONTROL_DIR/"$1"
   fi
     SUITESTATE=$(grep "SCRIPTSTATE" $SUITE_CONTROL_DIR/"$1" | awk -F'=' '{print $2}')
+    source $SUITE_INSTALL_DIR/"$1".sh
   if [ "$FORCE" == "true" ]; then
-    run-installer "$1"
+    "$1"-install-package | tee $LOGFILE
     sed -i -- 's/SCRIPTSTATE='"$SUITESTATE"'/SCRIPTSTATE=installed/g' $SUITE_CONTROL_DIR/"$1"
   elif [ "$SUITESTATE" == "installed" ]; then
     echo "$1 is already installed, trying upgrade script..."
@@ -139,13 +121,17 @@ function install-suite {
     echo "Upgrade script is not available..."
     echo "You can force run the install script like this:"
     echo "sudo hassbian-config -f install $1"
-    exit
+    return 0
   fi
-    run-upgrader "$1"
+    "$1"-upgrade-package | tee $LOGFILE
     sed -i -- 's/SCRIPTSTATE='"$SUITESTATE"'/SCRIPTSTATE=installed/g' $SUITE_CONTROL_DIR/"$1"
   else
-
+    source $SUITE_INSTALL_DIR/"$1".sh
+    "$1"-install-package | tee $LOGFILE
     sed -i -- 's/SCRIPTSTATE='"$SUITESTATE"'/SCRIPTSTATE=installed/g' $SUITE_CONTROL_DIR/"$1"
+  fi
+  if [ "$DEBUG" == "true" ]; then
+    set +x
   fi
   return 0
 }
@@ -155,6 +141,9 @@ function upgrade-suite {
     echo "This script must be run with sudo. Use 'sudo hassbian-config upgrade $1'" 1>&2
     return 1
   fi
+  if [ "$DEBUG" == "true" ]; then
+    set -x
+  fi
   UPGRADE=$(grep "$1"-upgrade-package $SUITE_INSTALL_DIR/"$1".sh)
   if [ "$UPGRADE" == "" ]; then
     echo "Upgrade script is not available..."
@@ -162,7 +151,11 @@ function upgrade-suite {
     echo "sudo hassbian-config -f install $1"
   fi
   check-permission
-  run-upgrader "$1"
+  source $SUITE_INSTALL_DIR/"$1".sh
+  "$1"-upgrade-package | tee $LOGFILE
+  if [ "$DEBUG" == "true" ]; then
+    set +x
+  fi
   return 0
 }
 


### PR DESCRIPTION
### Description:
This will add `-D | --debug` support to the tool.
It sets `set -x` before execution.

The output isn't pretty, but it works:
![image](https://user-images.githubusercontent.com/15093472/36951312-77534214-2002-11e8-9117-5e2a3587f652.png)


### Checklist:
  - [X] The code change is tested and works locally.
  - [N/A] Script has validation check of the job.
  
#### If pertinent:
  - [X] Created/Updated documentation at `/docs`
  
