### PR TITLE
Change Appdaemon's default conf

### DIFF
--- a/package/opt/hassbian/suites/files/appdaemon.conf
+++ b/package/opt/hassbian/suites/files/appdaemon.conf
@@ -4,4 +4,4 @@ appdaemon:
     HASS:
       type: hass
       ha_url: http://127.0.0.1:8123
-      ha_key:
+      #ha_key:

--- a/package/opt/hassbian/suites/files/appdaemon.conf
+++ b/package/opt/hassbian/suites/files/appdaemon.conf
@@ -1,7 +1,7 @@
-AppDaemon:
-  logfile: STDOUT
-  errorfile: STDERR
-  log_generations: 3
+appdaemon:
   threads: 10
-HASS:
-  ha_url: http://127.0.0.1:8123
+  plugins:
+    HASS:
+      type: hass
+      ha_url: http://127.0.0.1:8123
+      ha_key:


### PR DESCRIPTION
Since Appdaemon v3 officially published, then we should change the default `conf` to meet with new format.

### Description:

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

### Checklist:
  - [x] The code change is tested and works locally.
  - [x] Script has validation check of the job.
  
#### If pertinent:
  - [ ] Created/Updated documentation at `/docs`
  
