### PR TITLE
AppDaemon: Changes to make it work with the new version.

### DIFF
--- a/package/opt/hassbian/suites/appdaemon.sh
+++ b/package/opt/hassbian/suites/appdaemon.sh
@@ -17,6 +17,11 @@ if [ "$ACCEPT" != "true" ]; then
     echo -n "Do you want to add Samba share for AppDaemon configuration? [N/y] : "
     read -r SAMBA
   fi
+  echo -n "Enter your Home Assistant API password: "
+  read -s -r HOMEASSISTANT_PASSWORD
+  printf "\\n"
+else
+  HOMEASSISTANT_PASSWORD=""
 fi
 
 echo "Creating directory for AppDaemon Venv"
@@ -42,7 +47,9 @@ pip3 install appdaemon
 
 echo "Copying AppDaemon config file"
 cp /opt/hassbian/suites/files/appdaemon.conf /home/homeassistant/appdaemon/appdaemon.yaml
-touch /home/homeassistant/appdaemon/apps.yaml
+if [ ! -z "${HOMEASSISTANT_PASSWORD}" ]; then
+    sed -i 's/#ha_key:/ha_key: $HOMEASSISTANT_PASSWORD/g' /home/homeassistant/appdaemon/appdaemon.yaml
+fi
 
 echo "Deactivating virtualenv"
 deactivate


### PR DESCRIPTION
### Description:
`./apps.yaml` is deprecated resulting in an error loop when starting if the file is present.
Added option to set ha_key, this is dependent on #140 

**Related issue (if applicable):** Fixes #142 

### Checklist:
  - [X] The code change is tested and works locally.
  - [N/A] Script has validation check of the job. _Change to existing script._
  
#### If pertinent:
  - [N/A] Created/Updated documentation at `/docs`
  
