### PR TITLE
hassbian-config: Minor change to show-installed.

### DIFF
--- a/docs/hassbian_config.md
+++ b/docs/hassbian_config.md
@@ -12,6 +12,7 @@ where command is one of:
 - `show` This will show you all available suites.
 - `log` This will show you the log of last hassbian-config operation.
 - `share-log` This will generate an hastebin link of the last hassbian-config operation.
+- `show-installed` Generates a list of installed suites.
 
 Optional flags:
 - `-Y | --accept` This will accept defaults on scripts that allow this.

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -23,7 +23,7 @@ function help {
   printf "%-8s\\t%s\\n" "  show-installed" "Generates a list of installed suites."
   printf "\\n"
   printf "available optional [options]:\\n"
-  printf "%-10s\\t%s\\n" " -Y | --accept" "Accept defaults on scripts that allow this."
+  printf "%-10s\\t%s\\n" " -Y | --accept" "Accept defaults on scripts that allows this."
   printf "%-10s\\t%s\\n" " -F | --force" "Force run an script, this is useful if you need to reinstall a package."
   printf "%-10s\\t%s\\n" " -D | --debug" "This will output every comand to the console."
   printf "%-10s\\t%s\\n" " -B | --beta" "This will install the current beta version if implemented."

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -15,15 +15,16 @@ function help {
   printf "\\n"
   printf "usage: hassbian-config [command] [suite] [options]\\n"
   printf "where [command] is one of:\\n"
-  printf "%-8s\\t%s\\n" "  install" "Installs a software [suite]"
-  printf "%-8s\\t%s\\n" "  upgrade" "Upgrades a software [suite]"
-  printf "%-8s\\t%s\\n" "  show" "To see available [suite] for install/upgrade"
-  printf "%-8s\\t%s\\n" "  log" "Displays an log of the last operation"
-  printf "%-8s\\t%s\\n" "  share-log" "Generates an hastebin link of the last operation"
+  printf "%-8s\\t%s\\n" "  install" "Installs a software [suite]."
+  printf "%-8s\\t%s\\n" "  upgrade" "Upgrades a software [suite]."
+  printf "%-8s\\t%s\\n" "  show" "To see available [suite] for install/upgrade."
+  printf "%-8s\\t%s\\n" "  log" "Displays an log of the last operation."
+  printf "%-8s\\t%s\\n" "  share-log" "Generates an hastebin link of the last operation."
+  printf "%-8s\\t%s\\n" "  show-installed" "Generates a list of installed suites."
   printf "\\n"
   printf "available optional [options]:\\n"
-  printf "%-10s\\t%s\\n" " -Y | --accept" "Accept defaults on scripts that allow this"
-  printf "%-10s\\t%s\\n" " -F | --force" "Force run an script, this is useful if you need to reinstall a package"
+  printf "%-10s\\t%s\\n" " -Y | --accept" "Accept defaults on scripts that allow this."
+  printf "%-10s\\t%s\\n" " -F | --force" "Force run an script, this is useful if you need to reinstall a package."
   printf "%-10s\\t%s\\n" " -D | --debug" "This will output every comand to the console."
   printf "%-10s\\t%s\\n" " -B | --beta" "This will install the current beta version if implemented."
   printf "%-10s\\t%s\\n" " --dev" "This will install the current development version if implemented."
@@ -190,12 +191,13 @@ function verify-suite {
 
 function show-installed-suites {
   INSTALLERS=$(find $SUITE_INSTALL_DIR/ -maxdepth 1 -type f | sort | awk -F'/' ' {print $NF}' | awk -F. '{print $1}')
+  echo "These suites are installed:"
   for i in $INSTALLERS
   do
   if [ -f "$SUITE_CONTROL_DIR/$i" ]; then
     STATE=$(grep "SCRIPTSTATE=installed" $SUITE_CONTROL_DIR/"$i" | awk -F'=' '{print $2}')
     if [ "$STATE" != "" ]; then
-      echo "$i:" "$STATE"
+      echo "$i"
     fi
   fi
   done


### PR DESCRIPTION
## Description:
Some minor rework to the function `show-installed-suites`
Also added it to the --help and /docs/hassbian-config.md

## Checklist (Required):
  - [X] The code change is tested and works locally.
  - [X] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [N/A] Script has validation check of the job.
  - [X] Created/Updated documentation at `/docs`
