### PR TITLE
hassbian-config: Added checks for RPiZero on suites that won't run.

### DIFF
--- a/docs/cloud9.md
+++ b/docs/cloud9.md
@@ -1,6 +1,8 @@
 ## Description
 Cloud9 SDK is an webservice IDE that makes it easy to manage your configuration files.
 
+*This suite can't be installed on Raspberry Pi Zero*  
+
 ## Installation
 ```bash
 $ sudo hassbian-config install cloud9

--- a/docs/homebridge.md
+++ b/docs/homebridge.md
@@ -4,7 +4,9 @@ This will allow you to control your home with Apple's HomeKit (Siri on iOS, OSX 
 By default all devices are hidden, and you will need to add som entries in your `customize.yaml` configuration.
 You can learn more about this in the [Home Assistant for Homebridge repo.](https://github.com/home-assistant/homebridge-homeassistant#customization)  
 
-_NB!: This install script will fail resulting in your Pi to reboot, if you do not use an recommended level power supply._
+_NB!: This install script will fail resulting in your Pi to reboot, if you do not use an recommended level power supply._  
+
+*This suite can't be installed on Raspberry Pi Zero*  
 
 ## Installation
 ```

--- a/docs/mosquitto.md
+++ b/docs/mosquitto.md
@@ -1,6 +1,8 @@
 ## Description
 This script installs the MQTT Mosquitto server. Repository from the Mosquitto project is added to package system and the official packages for Debian are installed. Additionally, this script helps you create your first MQTT user that can be used with Home Assistant.
 
+*This suite can't be installed on Raspberry Pi Zero*  
+
 ## Installation
 ```
 $ sudo hassbian-config install mosquitto

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -100,6 +100,20 @@ function check-permission {
   return 0
 }
 
+function raspberry_pi_zero_check {
+## Start check for Raspberry Pi Zero
+if [ "$FORCE" != "true" ]; then
+  REVCODE=$(sudo cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' | sed 's/^ *//g' | sed 's/ *$//g')
+  if [ "$REVCODE" = "90092" ] || [ "$REVCODE" = "90093" ] || [ "$REVCODE" = "0x9000C1" ]; then
+    if [[ "$1" =~ ^(mosquitto|homebridge|cloud9)$ ]]; then
+      echo "This suite can't be installed on Raspberry Pi Zero..."
+      exit 0
+    fi
+  fi
+fi
+## End check for Raspberry Pi Zero
+
+}
 function share-log {
   if [ ! -f $LOGFILE ];then
     echo "No logfile, exiting..."
@@ -149,6 +163,7 @@ function run-suite { #This is the function the actually run install/upgrade.
 
 function install-suite { #This function do checks if we can/want to install.
   check-permission
+  raspberry_pi_zero_check "$1"
   INSTALL=$(grep "$1"-install-package "$SUITE_INSTALL_DIR/$1".sh) #Checking if suite has install function.
   SUITESTATE=$(if [ -f "$SUITE_CONTROL_DIR/$1" ]; then grep "SCRIPTSTATE" "$SUITE_CONTROL_DIR/$1" | awk -F'=' '{print $2}'; else echo ""; fi) #Checking current suite state.
   if [ "$FORCE" == "true" ]; then #Go straight to run-suite if --force is used.


### PR DESCRIPTION
## Description:
Added extra checks for RPiZero on suites that won't run.

**Related issue (if applicable):** Fixes partially #147 

## Checklist (Required):
  - [X] The code change is tested and works locally. _Do not have a Pi Zero to test but done some mock testing_
  - [X] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [X] Script has validation check of the job.
  - [X] Created/Updated documentation at `/docs`
