### PR TITLE
Add check support for Pi Zero WH

### DIFF
--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -105,7 +105,7 @@ function raspberry_pi_zero_check {
 ## Start check for Raspberry Pi Zero
 if [ "$FORCE" != "true" ]; then
   REVCODE=$(sudo cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' | sed 's/^ *//g' | sed 's/ *$//g')
-  if [ "$REVCODE" = "90092" ] || [ "$REVCODE" = "90093" ] || [ "$REVCODE" = "0x9000C1" ]; then
+  if [ "$REVCODE" = "90092" ] || [ "$REVCODE" = "90093" ] || [ "$REVCODE" = "0x9000C1" ] || [ "$REVCODE" = "9000c1" ]; then
     if [[ "$1" =~ ^(mosquitto|homebridge|cloud9)$ ]]; then
       echo "This suite can't be installed on Raspberry Pi Zero..."
       exit 0


### PR DESCRIPTION
Here's feedback of my Pi Zero WH when execute `sudo cat /proc/cpuinfo`:
```
processor	: 0
model name	: ARMv6-compatible processor rev 7 (v6l)
BogoMIPS	: 997.08
Features	: half thumb fastmult vfp edsp java tls
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xb76
CPU revision	: 7

Hardware	: BCM2835
Revision	: 9000c1
Serial		: 000000002da6cad6
```
BTW, `c` is lowercase instead of `C`. I don't know it is the same as other models of Pi Zero.

## Description:

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
