### PR TITLE
hassbian-scrtips: Added daemon-reload.

### DIFF
--- a/package/opt/hassbian/suites/hassbian-script.sh
+++ b/package/opt/hassbian/suites/hassbian-script.sh
@@ -73,6 +73,9 @@ else
   echo "Cleanup"
   rm "$HASSBIAN_PACKAGE"
 fi
+
+systemctl daemon-reload
+
 echo
 echo "Upgrade is now done."
 echo


### PR DESCRIPTION
## Description:
Sometimes aftter upgrading hassbian-scrtipt, this message will appear when using `systemctl` on homeassistant:

```txt
Warning: home-assistant@homeassistant.service changed on disk. Run 'systemctl daemon-reload' to reload units.
```
This PR soves that by running `systemctl daemon-reload` at the end of the upgrade.

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [X] The code change is tested and works locally.
  - [X] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
