### PR TITLE
Appdaemon: Use newest python version when installing.

### DIFF
--- a/package/opt/hassbian/suites/appdaemon.sh
+++ b/package/opt/hassbian/suites/appdaemon.sh
@@ -24,6 +24,10 @@ else
   HOMEASSISTANT_PASSWORD=""
 fi
 
+echo "Checking python version to use..."
+PYTHONVER=$(echo /usr/local/lib/*python* | awk -F/ '{print $NF}')
+echo "Using $PYTHONVER..."
+
 echo "Creating directory for AppDaemon Venv"
 sudo mkdir /srv/appdaemon
 sudo chown -R homeassistant:homeassistant /srv/appdaemon
@@ -32,7 +36,7 @@ echo "Changing to the homeassistant user"
 sudo -u homeassistant -H /bin/bash << EOF
 
 echo "Creating AppDaemon venv"
-python3 -m venv /srv/appdaemon
+$PYTHONVER -m venv /srv/appdaemon
 
 echo "Changing to AppDaemon venv"
 source /srv/appdaemon/bin/activate


### PR DESCRIPTION
## Description:
This will use the newest version of python installed on the unit when creating venv.

**Related issue (if applicable):** Fixes #154 

## Checklist (Required):
  - [X] The code change is tested and works locally.
  - [X] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
