### PR TITLE
homeassistant: Restart after upgrade.

### DIFF
--- a/package/opt/hassbian/suites/homeassistant.sh
+++ b/package/opt/hassbian/suites/homeassistant.sh
@@ -99,8 +99,6 @@ EOF
     exit 1
   fi
 fi
-echo "Stopping Home Assistant"
-systemctl stop home-assistant@homeassistant.service
 
 echo "Changing to the homeassistant user"
 sudo -u homeassistant -H /bin/bash << EOF
@@ -121,7 +119,7 @@ deactivate
 EOF
 
 echo "Restarting Home Assistant"
-systemctl start home-assistant@homeassistant.service
+systemctl restart home-assistant@homeassistant.service
 
 echo "Checking the installation..."
 validation=$(pgrep -x hass)


### PR DESCRIPTION
## Description:
By changing it to this, Home Assistant can be upgraded while runnning.
This can be usefull for upgrading Home Assistant from Home Assistant, with shell_command, python_script, custom_component, and so on.

Acording to the documentation this is the default way to upgrade Home Assistant:
<https://www.home-assistant.io/docs/installation/updating/>
```text
The default way to update Home Assistant to the latest release, when available, is:

$ pip3 install --upgrade homeassistant

After updating, you must restart Home Assistant for the changes to take effect. This means that you will have to restart hass
```

## Checklist (Required):
  - [X] The code change is tested and works locally.
  - [X] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
