### PR TITLE
homeassistant: Version check for beta

### DIFF
--- a/package/opt/hassbian/suites/homeassistant.sh
+++ b/package/opt/hassbian/suites/homeassistant.sh
@@ -75,7 +75,18 @@ if [ "$DEV" == "true"  ]; then
   fi
 else
   echo "Checking current version"
-  if [ ! -z "${VERSIONNUMBER}" ]; then
+  if [ "$BETA" == "true"  ]; then
+  echo "Checking if there is an prerelease available..."
+  prerelease=$(curl -s https://api.github.com/repos/home-assistant/home-assistant/releases | grep '"prerelease": true')
+  if [ ! -z "${prerelease}" ]; then
+    echo "Prerelease found..."
+    newversion=$(curl -s https://api.github.com/repos/home-assistant/home-assistant/releases | grep tag_name | head -1 | awk -F'"' '{print $4}')
+  else
+    echo "Prerelease not found..."
+    echo "Trying latest stable version..."
+    newversion=$(curl -s https://api.github.com/repos/home-assistant/home-assistant/releases/latest | grep tag_name | awk -F'"' '{print $4}')
+  fi
+  elif [ ! -z "${VERSIONNUMBER}" ]; then
     verify=$(curl -s https://pypi.org/pypi/homeassistant/"$VERSIONNUMBER"/json)
     if [[ "$verify" = *"Not Found"* ]]; then
       echo "Version $VERSIONNUMBER not found..."

--- a/package/opt/hassbian/suites/homeassistant.sh
+++ b/package/opt/hassbian/suites/homeassistant.sh
@@ -76,16 +76,7 @@ if [ "$DEV" == "true"  ]; then
 else
   echo "Checking current version"
   if [ "$BETA" == "true"  ]; then
-  echo "Checking if there is an prerelease available..."
-  prerelease=$(curl -s https://api.github.com/repos/home-assistant/home-assistant/releases | grep '"prerelease": true')
-  if [ ! -z "${prerelease}" ]; then
-    echo "Prerelease found..."
-    newversion=$(curl -s https://api.github.com/repos/home-assistant/home-assistant/releases | grep tag_name | head -1 | awk -F'"' '{print $4}')
-  else
-    echo "Prerelease not found..."
-    echo "Trying latest stable version..."
-    newversion=$(curl -s https://api.github.com/repos/home-assistant/home-assistant/releases/latest | grep tag_name | awk -F'"' '{print $4}')
-  fi
+  newversion=$(curl -s https://api.github.com/repos/home-assistant/home-assistant/releases | grep tag_name | head -1 | awk -F'"' '{print $4}')
   elif [ ! -z "${VERSIONNUMBER}" ]; then
     verify=$(curl -s https://pypi.org/pypi/homeassistant/"$VERSIONNUMBER"/json)
     if [[ "$verify" = *"Not Found"* ]]; then


### PR DESCRIPTION
## Description:
When testing the previous PR, I must have been on an older version of HA..
This adds version check to beta script

**Related issue (if applicable):** Fixes #164 

## Checklist (Required):
  - [X] The code change is tested and works locally.
  - [X] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [X] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
