### PR TITLE
Python: Limit python version to 3.6.6.

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -5,6 +5,7 @@ This script will upgrade Python to the latest stable version.\
 It will also create a new virtual environment to be used for Home Assistant.\
 _This upgrade takes long time to finish._\
 _This prosess takes about a hour on an Raspberry Pi 3_
+_There are issues with 3.7.x and Home Assistant, this script has an limit of version 3.6.6_
 
 ## Upgrade
 ```

--- a/package/DEBIAN/control
+++ b/package/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: hassbian-scripts
-Version: 0.9.1
+Version: 0.9.2
 Priority: optional
 Architecture: all
 Depends: bash, wget, git, python3, python3-venv, python3-pip, python3-dev, bluetooth, libbluetooth-dev, avahi-daemon, build-essential, libssl-dev, libffi-dev, python-dev, libudev-dev

--- a/package/opt/hassbian/suites/python.sh
+++ b/package/opt/hassbian/suites/python.sh
@@ -31,8 +31,9 @@ else
   return 0
 fi
 
-#PYTHONVERSION=$(curl -s https://www.python.org/downloads/source/ | grep "Latest Python 3 Release" | cut -d "<" -f 3 | awk -F ' ' '{print $NF}')
-PYTHONVERSION=3.6.6 # Latest (3.7.0) break parts of Home Assistant.
+# PYTHONVERSION=$(curl -s https://www.python.org/downloads/source/ | grep "Latest Python 3 Release" | cut -d "<" -f 3 | awk -F ' ' '{print $NF}')
+# Latest (3.7.0) break parts of Home Assistant.
+PYTHONVERSION=3.6.6
 echo "Checking current version..."
 currentpython=$(sudo -u homeassistant -H /bin/bash << EOF | awk -F ' ' '{print $NF}'
 source /srv/homeassistant/bin/activate

--- a/package/opt/hassbian/suites/python.sh
+++ b/package/opt/hassbian/suites/python.sh
@@ -31,8 +31,8 @@ else
   return 0
 fi
 
-PYTHONVERSION=$(curl -s https://www.python.org/downloads/source/ | grep "Latest Python 3 Release" | cut -d "<" -f 3 | awk -F ' ' '{print $NF}')
-
+#PYTHONVERSION=$(curl -s https://www.python.org/downloads/source/ | grep "Latest Python 3 Release" | cut -d "<" -f 3 | awk -F ' ' '{print $NF}')
+PYTHONVERSION=3.6.6 # Latest (3.7.0) break parts of Home Assistant.
 echo "Checking current version..."
 currentpython=$(sudo -u homeassistant -H /bin/bash << EOF | awk -F ' ' '{print $NF}'
 source /srv/homeassistant/bin/activate


### PR DESCRIPTION
## Description:
Limits the version that is installed with the python upgrade script.

## Checklist (Required):
  - [X] The code change is tested and works locally.
  - [X] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [X] Script has validation check of the job.
  - [X] Created/Updated documentation at `/docs`
