### PR TITLE
Hassbian: make sure that crucial packages are not removed.

### DIFF
--- a/package/etc/apt/apt.d/01autoremove
+++ b/package/etc/apt/apt.d/01autoremove
@@ -1,0 +1,48 @@
+APT
+{
+  NeverAutoRemove
+  {
+	"^firmware-linux.*";
+	"^linux-firmware$";
+  };
+
+  VersionedKernelPackages
+  {
+	# linux kernels
+	"linux-image";
+	"linux-headers";
+	"linux-image-extra";
+	"linux-signed-image";
+	# kfreebsd kernels
+	"kfreebsd-image";
+	"kfreebsd-headers";
+	# hurd kernels
+	"gnumach-image";
+	# (out-of-tree) modules
+	".*-modules";
+	".*-kernel";
+	"linux-backports-modules-.*";
+        # tools
+        "linux-tools";
+  };
+
+  Never-MarkAuto-Sections
+  {
+	"metapackages";
+	"contrib/metapackages";
+	"non-free/metapackages";
+	"restricted/metapackages";
+	"universe/metapackages";
+	"multiverse/metapackages";
+  };
+
+  Move-Autobit-Sections
+  {
+	"oldlibs";
+	"contrib/oldlibs";
+	"non-free/oldlibs";
+	"restricted/oldlibs";
+	"universe/oldlibs";
+	"multiverse/oldlibs";
+  };
+};

--- a/package/etc/apt/apt.d/01autoremove
+++ b/package/etc/apt/apt.d/01autoremove
@@ -4,6 +4,8 @@ APT
   {
 	"^firmware-linux.*";
 	"^linux-firmware$";
+	"^hassbian-scripts$";
+	"^raspberrypi-kernel$";
   };
 
   VersionedKernelPackages


### PR DESCRIPTION
## Description:
safety guard for installations when running automated so we can say what files are nessary so the system can automatically remove then upon apt remove or autoremove

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [X] The code change is tested and works locally.
  - [X] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
