### PR TITLE
Hassbian: Added new alias `halog`

### DIFF
--- a/docs/homeassistant.md
+++ b/docs/homeassistant.md
@@ -54,10 +54,6 @@ source /srv/homeassistant/bin/activate
 
 When you are done, type `exit` to return to the `pi` user.
 
-***
-The installation script was originally contributed by [@Landrash](https://github.com/landrash).  
-The upgrade scripts was originally contributed by [@Ludeeus](https://github.com/ludeeus).
-
 ## Included bash aliases
 
 ### For the user `pi`
@@ -77,3 +73,7 @@ Alias | Command
 :--- | :---
 hacheckconf | `source /srv/homeassistant/bin/activate;hass --script check_config`
 hapyshell | `source /srv/homeassistant/bin/activate;cd ~/.homeassistant`
+
+***
+The installation script was originally contributed by [@Landrash](https://github.com/landrash).  
+The upgrade scripts was originally contributed by [@Ludeeus](https://github.com/ludeeus).

--- a/docs/homeassistant.md
+++ b/docs/homeassistant.md
@@ -1,31 +1,38 @@
 ## Description
+
 This is a copy of the installation script run during first boot of your Raspberry Pi with the [Hassbian image](https://github.com/home-assistant/pi-gen/releases/latest)\
 And an easy way to upgrade Home Assistant to the newest version.
 
 ## Installation
+
 _**NB!: This is installed by Hassbian, and should not be run additionally**_
-```
-$ sudo hassbian-config install homeassistant
+
+```bash
+sudo hassbian-config install homeassistant
 ```
 
 ## Upgrade
-```
-$ sudo hassbian-config upgrade homeassistant
+
+```bash
+sudo hassbian-config upgrade homeassistant
 ```
 
 ## Upgrade to beta channel
-```
-$ sudo hassbian-config upgrade homeassistant --beta
+
+```bash
+sudo hassbian-config upgrade homeassistant --beta
 ```
 
 ## Upgrade to dev branch
-```
-$ sudo hassbian-config upgrade homeassistant --dev
+
+```bash
+sudo hassbian-config upgrade homeassistant --dev
 ```
 
 ## Upgrade to to a specific version
-```
-$ sudo hassbian-config upgrade homeassistant=0.65.6
+
+```bash
+sudo hassbian-config upgrade homeassistant=0.65.6
 ```
 
 ## Additional info
@@ -37,15 +44,36 @@ Start service: | `sudo systemctl start home-assistant@homeassistant.service`
 Stop service: | `sudo systemctl stop home-assistant@homeassistant.service`
 Restart service: | `sudo systemctl restart home-assistant@homeassistant.service`
 Service status: | `sudo systemctl status home-assistant@homeassistant.service`
-|
 
 Enter the virtual environment where Home Assistant is installed as `homeassistant`:
-```
+
+```bash
 sudo su -s /bin/bash homeassistant
 source /srv/homeassistant/bin/activate
 ```
+
 When you are done, type `exit` to return to the `pi` user.
 
 ***
 The installation script was originally contributed by [@Landrash](https://github.com/landrash).  
 The upgrade scripts was originally contributed by [@Ludeeus](https://github.com/ludeeus).
+
+## Included bash aliases
+
+### For the user `pi`
+
+Alias | Command
+:--- | :---
+halog | `sudo journalctl -f -u home-assistant@homeassistant.service`
+harestart | `sudo systemctl restart home-assistant@homeassistant.service`
+hashell | `sudo su -s /bin/bash homeassistant`
+hastart | `sudo systemctl start home-assistant@homeassistant.service`
+hastatus | `sudo systemctl status home-assistant@homeassistant.service`
+hastop | `sudo systemctl stop home-assistant@homeassistant.service`
+
+### For the user `homeassistant`
+
+Alias | Command
+:--- | :---
+hacheckconf | `source /srv/homeassistant/bin/activate;hass --script check_config`
+hapyshell | `source /srv/homeassistant/bin/activate;cd ~/.homeassistant`

--- a/package/home/pi/.bash_aliases
+++ b/package/home/pi/.bash_aliases
@@ -1,6 +1,6 @@
-alias hashell='sudo su -s /bin/bash homeassistant'
+alias halog='sudo journalctl -f -u home-assistant@homeassistant.service'
 alias harestart='sudo systemctl restart home-assistant@homeassistant.service'
-alias hastop='sudo systemctl stop home-assistant@homeassistant.service'
+alias hashell='sudo su -s /bin/bash homeassistant'
 alias hastart='sudo systemctl start home-assistant@homeassistant.service'
 alias hastatus='sudo systemctl status home-assistant@homeassistant.service'
-
+alias hastop='sudo systemctl stop home-assistant@homeassistant.service'


### PR DESCRIPTION
## Description:
Added new alias for the `pi` user:
```bash
alias halog='sudo journalctl -f -u home-assistant@homeassistant.service'
```

Also added docs for this well hidden feature :)

**Related issue (if applicable):** Fixes #N/A

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [x] Created/Updated documentation at `/docs`
