### PR TITLE
Cloud9: Added dedicated workspace and use symlink to homeassistant config.

### DIFF
--- a/docs/cloud9.md
+++ b/docs/cloud9.md
@@ -17,7 +17,7 @@ $ sudo hassbian-config upgrade cloud9
 Description | Command/value
 :--- | :---
 Running as: | homeassistant
-Default workspace: | /home/homeassistant/
+Default workspace: | /home/homeassistant/c9workspace/
 Default port: | 8181
 Start service: | `sudo systemctl start cloud9@homeassistant.service`
 Stop service: | `sudo systemctl stop cloud9@homeassistant.service`

--- a/package/opt/hassbian/suites/cloud9.sh
+++ b/package/opt/hassbian/suites/cloud9.sh
@@ -29,11 +29,12 @@ sudo -u homeassistant -H /bin/bash << EOF
   printf "Downloading and installing Cloud9 SDK...\\n"
   git clone git://github.com/c9/core.git /opt/c9sdk
   bash /opt/c9sdk/scripts/install-sdk.sh
-  echo '{"projecttree": {"@showhidden": false,"@hiddenFilePattern": ".n*,*c9*,.b*,.p*,.w*,*.db"}}' | tee /home/homeassistant/.c9/user.settings
-  mkdir /home/homeassistant/c9workspace
-  ln -s /home/homeassistant/.homeassistant/ /home/homeassistant/c9workspace
-  ln -s /home/homeassistant/.c9 /home/homeassistant/c9workspace
-  mv /home/homeassistant/c9workspace/.homeassistant /home/homeassistant/c9workspace/homeassistant
+  echo "Creating workspace for Cloud9."
+  mkdir -p /home/homeassistant/c9workspace/.c9
+  echo "Create default config."
+  echo '{"projecttree": {"@showhidden": false,"@hiddenFilePattern": ".*,.n*,*c9*,.b*,.p*,.w*,*.db"}}' | tee /home/homeassistant/c9workspace/.c9/user.settings
+  echo "Symlinking /home/homeassistant/.homeassistant to the workspace."
+  ln -s /home/homeassistant/.homeassistant/ /home/homeassistant/c9workspace/homeassistant
 EOF
 
 echo "Copying Cloud9 service file..."
@@ -98,6 +99,7 @@ rm /etc/systemd/system/cloud9@homeassistant.service
 sync
 bash /opt/c9sdk/scripts/uninstall-c9.sh
 rm -R /opt/c9sdk
+rm -R /home/homeassistant/c9workspace
 
 printf "\\e[32mRemoval done..\\e[0m\\n"
 }

--- a/package/opt/hassbian/suites/cloud9.sh
+++ b/package/opt/hassbian/suites/cloud9.sh
@@ -33,7 +33,7 @@ sudo -u homeassistant -H /bin/bash << EOF
   mkdir /home/homeassistant/c9workspace
   ln -s /home/homeassistant/.homeassistant/ /home/homeassistant/c9workspace
   ln -s /home/homeassistant/.c9 /home/homeassistant/c9workspace
-  mv /home/homeassistant/.homeassistant /home/homeassistant/homeassistant
+  mv /home/homeassistant/c9workspace/.homeassistant /home/homeassistant/c9workspace/homeassistant
 EOF
 
 echo "Copying Cloud9 service file..."

--- a/package/opt/hassbian/suites/cloud9.sh
+++ b/package/opt/hassbian/suites/cloud9.sh
@@ -30,6 +30,9 @@ sudo -u homeassistant -H /bin/bash << EOF
   git clone git://github.com/c9/core.git /opt/c9sdk
   bash /opt/c9sdk/scripts/install-sdk.sh
   echo '{"projecttree": {"@showhidden": true,"@hiddenFilePattern": ".n*,*c9*,.b*,.p*,.w*,*.db"}}' | tee /home/homeassistant/.c9/user.settings
+  mkdir /home/homeassistant/c9workspace
+  ln -s /home/homeassistant/.homeassistant/ /home/homeassistant/c9workspace
+  mv /home/homeassistant/.homeassistant /home/homeassistant/homeassistant
 EOF
 
 echo "Copying Cloud9 service file..."

--- a/package/opt/hassbian/suites/cloud9.sh
+++ b/package/opt/hassbian/suites/cloud9.sh
@@ -29,9 +29,10 @@ sudo -u homeassistant -H /bin/bash << EOF
   printf "Downloading and installing Cloud9 SDK...\\n"
   git clone git://github.com/c9/core.git /opt/c9sdk
   bash /opt/c9sdk/scripts/install-sdk.sh
-  echo '{"projecttree": {"@showhidden": true,"@hiddenFilePattern": ".n*,*c9*,.b*,.p*,.w*,*.db"}}' | tee /home/homeassistant/.c9/user.settings
+  echo '{"projecttree": {"@showhidden": false,"@hiddenFilePattern": ".n*,*c9*,.b*,.p*,.w*,*.db"}}' | tee /home/homeassistant/.c9/user.settings
   mkdir /home/homeassistant/c9workspace
   ln -s /home/homeassistant/.homeassistant/ /home/homeassistant/c9workspace
+  ln -s /home/homeassistant/.c9 /home/homeassistant/c9workspace
   mv /home/homeassistant/.homeassistant /home/homeassistant/homeassistant
 EOF
 

--- a/package/opt/hassbian/suites/files/cloud9.service
+++ b/package/opt/hassbian/suites/files/cloud9.service
@@ -4,6 +4,6 @@ After=network-online.target
 [Service]
 Type=simple
 User=homeassistant
-ExecStart=/opt/c9sdk/server.js -l 0.0.0.0 -a : -w /home/homeassistant
+ExecStart=/opt/c9sdk/server.js -l 0.0.0.0 -a : -w /home/homeassistant/c9workspace
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description:
Uses /home/homeassistant/c9workspace as the workspace.
.homeassistant are symlinked to that workspace as `homeassistant`

ctrl+e works for searching.

**Related issue (if applicable):** Fixes #177 

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
- [x] Script has validation check of the job.
- [x] Created/Updated documentation at `/docs`
