### PR TITLE
Homeassistant: Fixes revert issue.

### DIFF
--- a/package/opt/hassbian/suites/homeassistant.sh
+++ b/package/opt/hassbian/suites/homeassistant.sh
@@ -131,7 +131,7 @@ EOF
   if (( config_check_lines > 1 ));then
     if [ "$ACCEPT" != "true" ]; then
       echo -n "Config check failed for new version, do you want to revert? [Y/n] : "
-      read -r 
+      read -r RESPONSE
       if [ ! "$RESPONSE" ]; then
         RESPONSE="Y"
       fi


### PR DESCRIPTION
## Description:
The revert function of the update script for homeassistant always reverted.
Example:
```
Successfully installed homeassistant-0.79.2 pip-18.0
Deactivating virtualenv
Config check failed for new version, do you want to revert? [Y/n] : n
Looking in indexes: https://pypi.org/simple, https://www.piwheels.org/simple
Collecting homeassistant==0.79.0
```

This PR corrects that behavior.

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [ ] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
