### PR TITLE
Homeassistant: Add --force to initial install command.

### DIFF
--- a/package/etc/systemd/system/install_homeassistant.service
+++ b/package/etc/systemd/system/install_homeassistant.service
@@ -8,7 +8,7 @@ After=network.target
 
 [Service]
 ExecStartPre=/usr/local/bin/hassbian-config upgrade hassbian-script
-ExecStart=/usr/local/bin/hassbian-config install homeassistant
+ExecStart=/usr/local/bin/hassbian-config install homeassistant --force
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description:

This will ensure that the install scripts actually runs.
There have been some reports in Discord that even when manually starting the service does not work.

If this service is run twice (for example if there was a network issue during the first run), prior to this PR it would revert the second attempt to the upgrade function that would fail since there is nothing to upgrade.

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
