### PR TITLE
docs: Fixes tables for hassbian-config

### DIFF
--- a/docs/hassbian_config.md
+++ b/docs/hassbian_config.md
@@ -15,6 +15,7 @@ hassbian-config *command* *suite* *flag(optional)*
 ```
 
 where `*command*` is one of:
+
 Command | Description
 :--- | :---
 `install` | Use this to install an suite.
@@ -25,6 +26,7 @@ Command | Description
 `show-installed` | Generates a list of installed suites.
 
 **Optional flags:**
+
 Flag | Alt. flag | Description
 :--- | :--- | :---
 `--accept` | `-Y` | This will accept defaults on scripts that allow this.
@@ -34,6 +36,7 @@ Flag | Alt. flag | Description
 `--dev` | | This will install the current development version if implemented.
 
 **Other available commands:**
+
 Command | Alt. command | Description
 :--- | :--- | :---
 `--version` | - `-V` | This will show you the installed version of `hassbian-config`.


### PR DESCRIPTION
## Description:

For some reason, the markdown compiler GitHub uses requires an empty line here 🤷‍♂️ 
This looked good in VS Code 😄 

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [x] Created/Updated documentation at `/docs`
