### PR TITLE
DuckDns: fix typo in duckdns-install-package

### DIFF
--- a/package/opt/hassbian/suites/duckdns.sh
+++ b/package/opt/hassbian/suites/duckdns.sh
@@ -65,7 +65,7 @@ cd duckdns || exit
 echo "Creating a script file to be used by cron."
 echo "echo url='https://www.duckdns.org/update?domains=$domain&token=$token&ip=' | curl -k -o ~/duckdns/duck.log -K -" > duck.sh
 
-echo "Setting premissions..."
+echo "Setting permissions..."
 chmod 700 duck.sh
 
 echo "Creating cron job..."


### PR DESCRIPTION
## Description:
Small fix in the console output while installing duckdns

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
