### PR TITLE
DuckDns docs: add https hint and fix typo

### DIFF
--- a/docs/duckdns.md
+++ b/docs/duckdns.md
@@ -30,7 +30,7 @@ add this under `http:` to your `configuration.yaml`
   base_url: YOURDOMAIN.duckdns.org:PORTNUMBER
 ```
 
-Keep in mind that after you added the ssl keys to your config and restarted hassbian, your installation won't be available through http anymore but then only through https.
+Keep in mind that after you added the ssl keys to your config and restarted Home Assistant, your installation won't be available through http anymore but then only through https.
 
 ***
 

--- a/docs/duckdns.md
+++ b/docs/duckdns.md
@@ -1,9 +1,9 @@
 # Duck DNS
 
-This script adds an cron job to auto update you the WAN IP address for the
+This script adds a cron job which auto updates the WAN IP address for the
 defined domain.  
-Before running this script you should already have an
-[Duck DNS account][duckdns], during the installation you will be asked to
+Before running this script you should already have a
+[Duck DNS account][duckdns]. During the installation you will be asked to
 supply your domain name and the token for your account.
 
 ## Installation
@@ -29,6 +29,8 @@ add this under `http:` to your `configuration.yaml`
   ssl_key: /home/homeassistant/dehydrated/certs/YOURDOMAIN.duckdns.org/privkey.pem
   base_url: YOURDOMAIN.duckdns.org:PORTNUMBER
 ```
+
+Keep in mind that after you added the ssl keys to your config and restarted hassbian, your installation won't be available through http anymore but then only through https.
 
 ***
 


### PR DESCRIPTION
## Description:
After installing duckdns, adding the certificates, adjusting the config and restarting hassbian I was wondering why reloading my already opened tab with `hassbian.local:8123/` was returning nothing. 
Then I searched for any errors in the console logs or if I screwed up anywhere else.
I probably would have noticed earlier that I first needed to change the protocol in the URL if Chrome wasn't hiding the protocol nowadays...

Therefore I think a hint can spare others some time searching for errors.

While at it I also fixed a minor typo.

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`th 
