### PR TITLE
Add install script for the Bluetooth monitor script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ below for usage and instructions.
   - [HUE](/docs/hue.md)
   - [LibCEC](/docs/libcec.md)
   - [MariaDB](/docs/mariadb.md)
+  - [Monitor](/docs/monitor.md)
   - [Mosquitto](/docs/mosquitto.md)
   - [PostgreSQL](/docs/postgresql.md)
   - [MS SQL](/docs/mssql.md)

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -1,0 +1,41 @@
+# Monitor
+
+This script installs the Monitor script by [andrewjfreyer][andrewjfreyer].
+TL;DR: Bluetooth-based passive presence detection of beacons, cell phones, and any other bluetooth device. The system is useful for mqtt-based home automation.
+This script requires that the Mosquitto suite is already installed.
+After mqtt setting will need to be set configured and some customisation is required. Instructions can be found [here](https://github.com/andrewjfreyer/monitor#getting-started)
+
+## Installation
+
+```bash
+sudo hassbian-config install monitor
+```
+
+## Upgrade
+
+No script available, maybe you could write one?  
+If so, add an PR here when you are done:  
+[homeassistant/hassbian-scripts][repo]
+
+## Additional info
+
+Description | Command/value
+:--- | :---
+Running as: | root
+Configuration file: | /opt/monitor/address_blacklist
+Configuration file: | /opt/monitor/known_beacon_addresses  
+Configuration file: | /opt/monitor/known_static_addresses
+Configuration file: | /opt/monitor/mqtt_preferences    
+Start service: | `sudo systemctl start monitor.service`
+Stop service: | `sudo systemctl stop monitor.service`
+Restart service: | `sudo systemctl restart monitor.service`
+Service status: | `sudo systemctl status monitor.service`
+
+***
+
+This install script was originally contributed by [@Landrash][landrash]
+
+<!--- Links --->
+[andrewjfreyer]: https://github.com/andrewjfreyer
+[landrash]: https://github.com/landrash
+[repo]: https://github.com/home-assistant/hassbian-scripts/pulls

--- a/package/opt/hassbian/suites/monitor.sh
+++ b/package/opt/hassbian/suites/monitor.sh
@@ -27,13 +27,13 @@ fi
 
 echo "Creating Monitor folder..."
 mkdir /opt/monitor || exit
-cd /opt
+cd /opt || exit
 
 echo "Cloning Monitor git repository"
 git clone git://github.com/andrewjfreyer/monitor
 
 echo "Running interactive setup"
-cd /opt/monitor
+cd /opt/monitor || exit
 sudo bash /opt/monitor/monitor.sh
 
 echo "Checking the installation..."

--- a/package/opt/hassbian/suites/monitor.sh
+++ b/package/opt/hassbian/suites/monitor.sh
@@ -6,7 +6,7 @@ function monitor-show-short-info {
 function monitor-show-long-info {
   echo "This script installs Monitor a script for Bluetooth-based passive presence detection."
   echo "The Mosquitto suite will also be installed since it's a dependency for Monitor."
-  echo "This script also installs a service that can be enabled to run Monitor."
+  echo "This script also optionaly installs a service that can be enabled to run Monitor."
 }
 
 function monitor-show-copyright-info {
@@ -22,7 +22,7 @@ if [ ! -z "${validation}" ]; then
   echo "Existing Mosquitto install detected. Skipping install of Mosquitto."
 else
   echo "Installing Mosquitto"
-sudo hassbian-config install mosquitto
+hassbian-config install mosquitto accept
 fi
 
 echo "Creating Monitor folder..."
@@ -34,7 +34,7 @@ git clone git://github.com/andrewjfreyer/monitor
 
 echo "Running interactive setup"
 cd /opt/monitor || exit
-sudo bash /opt/monitor/monitor.sh
+bash /opt/monitor/monitor.sh
 
 echo "Checking the installation..."
 if [ ! -f /opt/monitor/monitor.sh ]; then

--- a/package/opt/hassbian/suites/monitor.sh
+++ b/package/opt/hassbian/suites/monitor.sh
@@ -34,7 +34,7 @@ git clone git://github.com/andrewjfreyer/monitor
 
 echo "Running interactive setup"
 cd /opt/monitor || exit
-chmod /opt/monitor/monitor.sh || exit
+chmod +x /opt/monitor/monitor.sh || exit
 bash /opt/monitor/monitor.sh
 
 echo "Checking the installation..."

--- a/package/opt/hassbian/suites/monitor.sh
+++ b/package/opt/hassbian/suites/monitor.sh
@@ -22,7 +22,7 @@ if [ ! -z "${validation}" ]; then
   echo "Existing Mosquitto install detected. Skipping install of Mosquitto."
 else
   echo "Installing Mosquitto"
-hassbian-config install mosquitto accept
+hassbian-config install mosquitto --accept
 fi
 
 echo "Creating Monitor folder..."
@@ -34,6 +34,7 @@ git clone git://github.com/andrewjfreyer/monitor
 
 echo "Running interactive setup"
 cd /opt/monitor || exit
+chmod /opt/monitor/monitor.sh || exit
 bash /opt/monitor/monitor.sh
 
 echo "Checking the installation..."

--- a/package/opt/hassbian/suites/monitor.sh
+++ b/package/opt/hassbian/suites/monitor.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+function monitor-show-short-info {
+  echo "Setup for Monitor. Bluetooth-based passive presence detection."
+}
+
+function monitor-show-long-info {
+  echo "This script installs Monitor a script for Bluetooth-based passive presence detection."
+  echo "The Mosquitto suite will also be installed since it's a dependency for Monitor."
+  echo "This script also installs a service that can be enabled to run Monitor."
+}
+
+function monitor-show-copyright-info {
+  echo "Original concept by Landrash <https://github.com/landrash>."
+}
+
+function monitor-install-package {
+echo -n "Installing Mosquitto package: "
+
+echo "Checking the installation..."
+validation=$(pgrep -f mosquitto)
+if [ ! -z "${validation}" ]; then
+  echo "Existing Mosquitto install detected. Skipping install of Mosquitto."
+else
+  echo "Installing Mosquitto"
+sudo hassbian-config install mosquitto
+fi
+
+echo "Creating Monitor folder..."
+mkdir /opt/monitor || exit
+cd /opt
+
+echo "Cloning Monitor git repository"
+git clone git://github.com/andrewjfreyer/monitor
+
+echo "Running interactive setup"
+cd /opt/monitor
+sudo bash /opt/monitor/monitor.sh
+
+echo "Checking the installation..."
+if [ ! -f /opt/monitor/monitor.sh ]; then
+  validation=""
+else
+  validation="ok"
+fi
+
+if [ ! -z "${validation}" ]; then
+  echo
+  echo -e "\\e[32mInstallation done..\\e[0m"
+  echo -e "Update of mqtt_preferences is required found at /opt/monitor/mqtt_prefences"
+  echo -e "Some further configuration is required and details can be found here https://github.com/andrewjfreyer/monitor#getting-started "
+  echo
+else
+  echo
+  echo -e "\\e[31mInstallation failed..."
+  echo
+  return 1
+fi
+return 0
+}
+
+[[ "$_" == "$0" ]] && echo "hassbian-config helper script; do not run directly, use hassbian-config instead"


### PR DESCRIPTION
## Description:
Adds install script for the Bluetooth [Montitor](https://github.com/andrewjfreyer/monitor) script by [andrewjfreyer](https://github.com/andrewjfreyer)

**  Depends on changes in #201 **

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [x] Script has validation check of the job.
  - [x] Created/Updated documentation at `/docs`
