### PR TITLE
Shouldn't the dep on python-dev really be on python3-dev ?

### DIFF
--- a/package/DEBIAN/control
+++ b/package/DEBIAN/control
@@ -2,7 +2,7 @@ Package: hassbian-scripts
 Version: 0.9.1
 Priority: optional
 Architecture: all
-Depends: bash, wget, git, python3, python3-venv, python3-pip, python3-dev, bluetooth, libbluetooth-dev, avahi-daemon, build-essential, libssl-dev, libffi-dev, python-dev, libudev-dev
+Depends: bash, wget, git, python3, python3-venv, python3-pip, python3-dev, bluetooth, libbluetooth-dev, avahi-daemon, build-essential, libssl-dev, libffi-dev, python3-dev, libudev-dev
 Maintainer: Fredrik Lindqvist <github.com/Landrash>
 Homepage: www.home-assistant.io
 Description: Hassbian scripts


### PR DESCRIPTION
It seems that this dep is keeping the whole python2.7 suite installed. Is there any point in keeping it ?

## Description:

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [ ] The code change is tested and works locally.
  - [ ] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
