### PR TITLE
homebridge: Add removal script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ below for usage and instructions.
   - [Duck DNS](/docs/duckdns.md)
   - [Hassbian](/docs/hassbian.md)
   - [Home Assistant](/docs/homeassistant.md)
+  - [Homebridge](/docs/homebridge.md)
   - [HUE](/docs/hue.md)
   - [LibCEC](/docs/libcec.md)
   - [MariaDB](/docs/mariadb.md)

--- a/docs/homebridge.md
+++ b/docs/homebridge.md
@@ -3,6 +3,8 @@
 **Installation of this script has been deprecated in favor of the
 [`homekit` component](homekit_component)**
 
+This script only removes a previously installed installation of homebridge.
+
 ## Remove
 
 ```bash

--- a/docs/homebridge.md
+++ b/docs/homebridge.md
@@ -1,0 +1,13 @@
+# Description
+
+**Installation of this script has been deprecated in favor of the
+[`homekit` component](homekit_component)**
+
+## Remove
+
+```bash
+sudo hassbian-config remove homebridge
+```
+
+<!--- Links --->
+[homekit_component]:https://www.home-assistant.io/components/homekit/

--- a/package/opt/hassbian/suites/homebridge.sh
+++ b/package/opt/hassbian/suites/homebridge.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+function homebridge-show-short-info {
+    echo "Removes Homebridge from this system."
+}
+
+function homebridge-show-long-info {
+    echo "Removes Homebridge from this system."
+}
+
+function homebridge-show-copyright-info {
+    echo "Original concept by Ludeeus <https://github.com/ludeeus>."
+}
+
+function homebridge-install-package {
+    echo "The installation of homebrige has been deprecated in favor of the 'homekit' component."
+    echo "To remove homebridge from this system run 'sudo hassbian-config remove homebridge.'"
+}
+
+function homebridge-remove-package {
+    echo "Starting removal of Homebridge."
+
+    echo "Removing service."
+    systemctl stop homebridge.service
+    systemctl disable homebridge.service
+    rm /etc/systemd/system/homebridge.service
+    systemctl daemon-reload
+
+    echo "Removing the homebridge user."
+    deluser --remove-home homebridge
+
+    echo "Removing homebridge."
+    npm remove -g homebridge-homeassistant
+    npm remove -g --unsafe-perm homebridge hap-nodejs node-gyp
+
+    return 0
+}
+
+[[ "$_" == "$0" ]] && echo "hassbian-config helper script; do not run directly, use hassbian-config instead"


### PR DESCRIPTION
## Description:

This will add back the `homebridge` files that were removed in #182 
The install function are "removed" and there is now only possible to remove homebridge with this script.

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [X] The code change is tested and works locally.
  - [X] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [X] Created/Updated documentation at `/docs`
