### PR TITLE
Add MOTD to the Hassbian image

### DIFF
--- a/package/DEBIAN/control
+++ b/package/DEBIAN/control
@@ -1,8 +1,8 @@
 Package: hassbian-scripts
-Version: 0.9.1
+Version: 0.9.3
 Priority: optional
 Architecture: all
-Depends: bash, wget, git, python3, python3-venv, python3-pip, python3-dev, bluetooth, libbluetooth-dev, avahi-daemon, build-essential, libssl-dev, libffi-dev, python-dev, libudev-dev
+Depends: bash, wget, git, python3, python3-venv, python3-pip, python3-dev, bluetooth, libbluetooth-dev, avahi-daemon, build-essential, libssl-dev, libffi-dev, python-dev,libudev-dev, zip, nodejs, apt-transport-https, hcidump, bc, figlet
 Maintainer: Fredrik Lindqvist <github.com/Landrash>
 Homepage: www.home-assistant.io
 Description: Hassbian scripts

--- a/package/DEBIAN/control
+++ b/package/DEBIAN/control
@@ -2,7 +2,7 @@ Package: hassbian-scripts
 Version: 0.9.3
 Priority: optional
 Architecture: all
-Depends: bash, wget, git, python3, python3-venv, python3-pip, python3-dev, bluetooth, libbluetooth-dev, avahi-daemon, build-essential, libssl-dev, libffi-dev, python-dev,libudev-dev, zip, nodejs, apt-transport-https, hcidump, bc, figlet
+Depends: bash, wget, git, python3, python3-venv, python3-pip, python3-dev, bluetooth, libbluetooth-dev, avahi-daemon, build-essential, libssl-dev, libffi-dev, python-dev,libudev-dev, zip, nodejs, apt-transport-https, bluez-hcidump, bc, figlet
 Maintainer: Fredrik Lindqvist <github.com/Landrash>
 Homepage: www.home-assistant.io
 Description: Hassbian scripts

--- a/package/DEBIAN/control
+++ b/package/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: hassbian-scripts
-Version: 0.9.3
+Version: 0.9.1
 Priority: optional
 Architecture: all
 Depends: bash, wget, git, python3, python3-venv, python3-pip, python3-dev, bluetooth, libbluetooth-dev, avahi-daemon, build-essential, libssl-dev, libffi-dev, python-dev,libudev-dev, zip, nodejs, apt-transport-https, bluez-hcidump, bc, figlet

--- a/package/etc/update-motd.d/10-display-hostname
+++ b/package/etc/update-motd.d/10-display-hostname
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/usr/bin/figlet "$(hostname)" 
+
+
+

--- a/package/etc/update-motd.d/20-sysinfo
+++ b/package/etc/update-motd.d/20-sysinfo
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# get load averages
+IFS=" " read LOAD1 LOAD5 LOAD15 <<<$(/bin/cat /proc/loadavg | awk '{ print $1,$2,$3 }')
+# get free memory
+IFS=" " read USED FREE TOTAL <<<$(free -htm | grep "Mem" | awk {'print $3,$4,$2'})
+# get processes
+PROCESS=`ps -eo user=|sort|uniq -c | awk '{ print $2 " " $1 }'`
+PROCESS_ALL=`echo "$PROCESS"| awk {'print $2'} | awk '{ SUM += $1} END { print SUM }'`
+PROCESS_ROOT=`echo "$PROCESS"| grep root | awk {'print $2'}`
+PROCESS_USER=`echo "$PROCESS"| grep -v root | awk {'print $2'} | awk '{ SUM += $1} END { print SUM }'`
+
+W="\e[0;39m"
+G="\e[1;32m"
+
+echo -e "
+${W}system info:
+$W  Distro......: $W`cat /etc/*release | grep "PRETTY_NAME" | cut -d "=" -f 2- | sed 's/"//g'`
+$W  Kernel......: $W`uname -sr`
+
+$W  Uptime......: $W`uptime -p`
+$W  Load........: $G$LOAD1$W (1m), $G$LOAD5$W (5m), $G$LOAD15$W (15m)
+$W  Processes...:$W $G$PROCESS_ROOT$W (root), $G$PROCESS_USER$W (user) | $G$PROCESS_ALL$W (total)
+
+$W  CPU.........: $W`cat /proc/cpuinfo | grep "model name" | cut -d ' ' -f3- | awk {'print $0'} | head -1`
+$W  Memory......: $G$USED$W used, $G$FREE$W free, $G$TOTAL$W in total$W"

--- a/package/etc/update-motd.d/30-services
+++ b/package/etc/update-motd.d/30-services
@@ -27,7 +27,6 @@ for i in ${!services[@]}; do
         out+="${services[$i]}:,${red}${service_status[$i]}${undim}\\n"
     fi
     # insert \n every $COLUMNS column
-    if [ $((($i+1) % $COLUMNS)) -eq 0 ]; then
         out+="\n"
     fi
 done

--- a/package/etc/update-motd.d/30-services
+++ b/package/etc/update-motd.d/30-services
@@ -7,7 +7,7 @@ green="\e[1;32m"
 red="\e[1;31m"
 undim="\e[0m"
 
-services=("appdaemon@homeassistant" "home-assistant@homeassistant" "mosquitto")
+services=("home-assistant@homeassistant")
 # sort services
 IFS=$'\n' services=($(sort <<<"${services[*]}"))
 unset IFS

--- a/package/etc/update-motd.d/30-services
+++ b/package/etc/update-motd.d/30-services
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# set column width
+COLUMNS=3
+# colors
+green="\e[1;32m"
+red="\e[1;31m"
+undim="\e[0m"
+
+services=("appdaemon@homeassistant" "home-assistant@homeassistant" "mosquitto")
+# sort services
+IFS=$'\n' services=($(sort <<<"${services[*]}"))
+unset IFS
+
+service_status=()
+# get status of all services
+for service in "${services[@]}"; do
+    service_status+=($(systemctl is-active "$service"))
+done
+
+out=""
+for i in ${!services[@]}; do
+    # color green if service is active, else red
+    if [[ "${service_status[$i]}" == "active" ]]; then
+        out+="${services[$i]}:,${green}${service_status[$i]}${undim},"
+    else
+        out+="${services[$i]}:,${red}${service_status[$i]}${undim},"
+    fi
+    # insert \n every $COLUMNS column
+    if [ $((($i+1) % $COLUMNS)) -eq 0 ]; then
+        out+="\n"
+    fi
+done
+out+="\n"
+
+printf "\nservices:\n"
+printf "$out" | column -ts $',' | sed -e 's/^/  /'

--- a/package/etc/update-motd.d/30-services
+++ b/package/etc/update-motd.d/30-services
@@ -27,7 +27,6 @@ for i in ${!services[@]}; do
         out+="${services[$i]}:,${red}${service_status[$i]}${undim}\\n"
     fi
     # insert \n every $COLUMNS column
-        out+="\n"
     fi
 done
 out+="\n"

--- a/package/etc/update-motd.d/30-services
+++ b/package/etc/update-motd.d/30-services
@@ -24,7 +24,7 @@ for i in ${!services[@]}; do
     if [[ "${service_status[$i]}" == "active" ]]; then
         out+="${services[$i]}:,${green}${service_status[$i]}${undim},"
     else
-        out+="${services[$i]}:,${red}${service_status[$i]}${undim},"
+        out+="${services[$i]}:,${red}${service_status[$i]}${undim}\\n"
     fi
     # insert \n every $COLUMNS column
     if [ $((($i+1) % $COLUMNS)) -eq 0 ]; then

--- a/package/etc/update-motd.d/30-services
+++ b/package/etc/update-motd.d/30-services
@@ -22,7 +22,7 @@ out=""
 for i in ${!services[@]}; do
     # color green if service is active, else red
     if [[ "${service_status[$i]}" == "active" ]]; then
-        out+="${services[$i]}:,${green}${service_status[$i]}${undim},"
+        out+="${services[$i]}:,${green}${service_status[$i]}${undim}\\n"
     else
         out+="${services[$i]}:,${red}${service_status[$i]}${undim}\\n"
     fi

--- a/package/etc/update-motd.d/30-services
+++ b/package/etc/update-motd.d/30-services
@@ -27,7 +27,6 @@ for i in ${!services[@]}; do
         out+="${services[$i]}:,${red}${service_status[$i]}${undim}\\n"
     fi
     # insert \n every $COLUMNS column
-    fi
 done
 out+="\n"
 


### PR DESCRIPTION
## Description:
Adds a MOTD on logon either over ssh or local based on the work of @yboetz.
Includes an update to dependencies also.

Name printed is derived from hostname of the machine. If changed this will also change.
Services are so far a static list but could be reworked to be added by hassbian-config but should not be governed by this PR since that would require changes to the tool in question.

![screenshot_20181021_234254](https://user-images.githubusercontent.com/1756938/47272845-7aab0980-d58b-11e8-9844-e91d28fbd563.png)

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)
