### PR TITLE
hassbian-config: Adds function to test PR's

### DIFF
--- a/package/etc/bash_completion.d/hassbian-config
+++ b/package/etc/bash_completion.d/hassbian-config
@@ -4,7 +4,7 @@ _hassbian-config()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="install upgrade remove show log share-log --version --help"
+    opts="developer-test-pr install upgrade remove show log share-log --version --help"
     altopts="--accept --force --debug --version --help --dev --beta"
     inst=$(find /opt/hassbian/suites/ -maxdepth 1 -type f | awk -F'/|_' ' {print $NF}' | awk -F. '{print $1}')
 

--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -102,6 +102,29 @@ function check-permission {
   return 0
 }
 
+function developer-test-pr { # This function fetches a active PR and build a installation package from that and install it on the system.
+    # This should only be used by maintainers to test PR's!
+    readonly PRNUMBER="$1"
+    readonly INSTALLDIR="/tmp/hassbian_config_install_${PRNUMBER}"
+    if [[ -z "$PRNUMBER" ]]; then
+        echo "Error: Missing PR argument."
+        echo ""
+        echo "Run: bash test_pr.sh PRNUMBER"
+        return 1
+    fi
+    git clone https://github.com/home-assistant/hassbian-scripts.git "$INSTALLDIR"
+    cd "$INSTALLDIR" || return 1
+    git fetch origin +refs/pull/"$PRNUMBER"/merge || return 1
+    git checkout FETCH_HEAD
+
+    chmod 755 -R package
+    dpkg-deb --build package/
+    apt install -y "$INSTALLDIR"/package.deb --reinstall --allow-downgrades
+
+    cd || return 1
+    rm -r "$INSTALLDIR"
+}
+
 function raspberry_pi_zero_check {
 ## Start check for Raspberry Pi Zero
 if [ "$FORCE" != "true" ]; then
@@ -305,6 +328,11 @@ case $COMMAND in
     else
       RUN="echo suite $SUITE doesn't exist."
     fi
+    shift # past argument
+    shift # past value
+    ;;
+  "developer-test-pr")
+    RUN="developer-test-pr $2"
     shift # past argument
     shift # past value
     ;;


### PR DESCRIPTION
## Description:
This will give us an easy way of testing future PR's
Notes: 
- This will **only** work on active PR's
- I have not included a documentation change.

## Checklist (Required):
  - [X] The code change is tested and works locally.
  - [X] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`


Testrun:
```bash
pi@hassbian:~ $ sudo hassbian-config developer-test-pr 202
Cloning into '/tmp/hassbian_config_install_202'...
remote: Enumerating objects: 64, done.
remote: Counting objects: 100% (64/64), done.
remote: Compressing objects: 100% (36/36), done.
remote: Total 1859 (delta 26), reused 50 (delta 21), pack-reused 1795
Receiving objects: 100% (1859/1859), 302.28 KiB | 0 bytes/s, done.
Resolving deltas: 100% (1006/1006), done.
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
Unpacking objects: 100% (1/1), done.
From https://github.com/home-assistant/hassbian-scripts
 * branch            refs/pull/202/merge -> FETCH_HEAD
Note: checking out 'FETCH_HEAD'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at f279563... Merge d1431efe9d837d21999f05b4d5b3b4a012172ccb into 2ee5a9f8332188c342288c914eb1592d658e437c
dpkg-deb: building package 'hassbian-scripts' in 'package.deb'.
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'hassbian-scripts' instead of '/tmp/hassbian_config_install_202/package.deb'
The following packages will be upgraded:
  hassbian-scripts
1 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/24.1 kB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 /tmp/hassbian_config_install_202/package.deb hassbian-scripts all 0.10.0 [24.1 kB]
apt-listchanges: Reading changelogs...
(Reading database ... 46241 files and directories currently installed.)
Preparing to unpack .../package.deb ...
Unpacking hassbian-scripts (0.10.0) over (0.9.3) ...
Setting up hassbian-scripts (0.10.0) ...
pi@hassbian:~ $ sudo hassbian-config developer-test-pr 202
usage: hassbian-config [command] [suite] [options]
run 'hassbian-config --help' to see all options
```
