### PR TITLE
hassbian-config: adds check-permission to developer-test-pr function

### DIFF
--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -104,6 +104,7 @@ function check-permission {
 
 function developer-test-pr { # This function fetches a active PR and build a installation package from that and install it on the system.
     # This should only be used by maintainers to test PR's!
+    check-permission
     readonly PRNUMBER="$1"
     readonly INSTALLDIR="/tmp/hassbian_config_install_${PRNUMBER}"
     if [[ -z "$PRNUMBER" ]]; then


### PR DESCRIPTION
## Description:

- adds check-permission to developer-test-pr function

## Checklist (Required):
  - [X] The code change is tested and works locally.
  - [X] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)
