### PR TITLE
Add install script for fail2ban

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ below for usage and instructions.
   - [AppDaemon](/docs/appdaemon.md)
   - [Cloud9](/docs/cloud9.md)
   - [Duck DNS](/docs/duckdns.md)
+  - [Fail2ban](/docs/fail2fail2ban.md)
   - [Hassbian](/docs/hassbian.md)
   - [Home Assistant](/docs/homeassistant.md)
   - [Homebridge](/docs/homebridge.md)

--- a/docs/fail2ban.md
+++ b/docs/fail2ban.md
@@ -1,0 +1,34 @@
+# Monitor
+
+This script installs the fail2ban service.
+Some further configuration is required after installation. More information [here](https://www.home-assistant.io/cookbook/fail2ban/).
+
+## Installation
+
+```bash
+sudo hassbian-config install fail2ban
+```
+
+## Upgrade
+
+There's nothing to upgrade.
+
+## Additional info
+
+Description | Command/value
+:--- | :---
+Running as: | root
+Configuration file: | /etc/fail2ban/filter.d/ha.conf
+Configuration file: | /etc/fail2ban/jail.d/ha.conf
+Start service: | `sudo systemctl start fail2ban.service`
+Stop service: | `sudo systemctl stop fail2ban.service`
+Restart service: | `sudo systemctl restart fail2ban.service`
+Service status: | `sudo systemctl status fail2ban.service`
+
+***
+
+This install script was originally contributed by [@Landrash][landrash]
+
+<!--- Links --->
+[landrash]: https://github.com/landrash
+[repo]: https://github.com/home-assistant/hassbian-scripts/pulls

--- a/docs/fail2ban.md
+++ b/docs/fail2ban.md
@@ -1,4 +1,4 @@
-# Monitor
+# Fail2Ban
 
 This script installs the fail2ban service.
 Some further configuration is required after installation. More information [here](https://www.home-assistant.io/cookbook/fail2ban/).

--- a/package/opt/hassbian/suites/fail2ban.sh
+++ b/package/opt/hassbian/suites/fail2ban.sh
@@ -52,7 +52,7 @@ logpath = /home/homeassistant/.homeassistant/home-assistant.log
 
 # 3600 seconds = 1 hour
 bantime = 3600
-bantime = 30 # during testing it is useful to have a short ban interval, comment out this line later
+#bantime = 30 # during testing it is useful to have a short ban interval, comment out this line later
 
 # Maximum amount of login attempts before IP is blocked
 maxretry = 3" > "$FAIL2BANJAIL"

--- a/package/opt/hassbian/suites/fail2ban.sh
+++ b/package/opt/hassbian/suites/fail2ban.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+function fail2ban-show-short-info {
+  echo "Setup for fail2ban service."
+}
+
+function fail2ban-show-long-info {
+  echo "This script installs the fail2ban service."
+  echo "Some further configuration is required after installation."
+}
+
+function fail2ban-show-copyright-info {
+  echo "Original concept by Landrash <https://github.com/landrash>."
+}
+
+function fail2ban-install-package {
+echo "Installing fail2ban package"
+apt install -y fail2ban
+
+FAIL2BANFILTER="/etc/fail2ban/filter.d/ha.conf"
+FAIL2BANJAIL="/etc/fail2ban/jail.d/ha.conf"
+
+echo "Creating configuration files"
+if [ -f $FAIL2BANFILTER ] ; then
+    echo "Configuration file exists. Skipping.."
+else
+
+echo "[INCLUDES]
+before = common.conf
+
+[Definition]
+failregex = ^%(__prefix_line)s.*Login attempt or request with invalid authentication from <HOST>.*$
+ignoreregex =" > "$FAIL2BANFILTER"
+
+fi
+
+if [ -f $FAIL2BANJAIL ] ; then
+    echo "Configuration file exists. Skipping.."
+else
+
+echo "[DEFAULT]
+# Email config
+sender = email@address.com
+destemail = email@address.com
+
+# Action %(action_mwl)s will ban the IP and send an email notification including whois data and log entries.
+action = %(action_mwl)s
+
+[ha]
+enabled = true
+filter = ha
+logpath = /home/homeassistant/.homeassistant/home-assistant.log
+
+# 3600 seconds = 1 hour
+bantime = 3600
+bantime = 30 # during testing it is useful to have a short ban interval, comment out this line later
+
+# Maximum amount of login attempts before IP is blocked
+maxretry = 3" > "$FAIL2BANJAIL"
+fi
+
+echo "Restarting fail2ban service"
+systemctl restart fail2ban
+
+echo "Checking the installation..."
+validation=$(which -x fail2ban-client)
+if [ ! -z "${validation}" ]; then
+  echo
+  echo -e "\\e[32mInstallation done.\\e[0m"
+  echo
+  echo "To continue have a look at https://www.home-assistant.io/cookbook/fail2ban/"
+  echo
+else
+  echo
+  echo -e "\\e[31mInstallation failed..."
+  echo
+  return 1
+fi
+return 0
+}
+
+[[ "$_" == "$0" ]] && echo "hassbian-config helper script; do not run directly, use hassbian-config instead"

--- a/package/opt/hassbian/suites/fail2ban.sh
+++ b/package/opt/hassbian/suites/fail2ban.sh
@@ -62,7 +62,7 @@ echo "Restarting fail2ban service"
 systemctl restart fail2ban
 
 echo "Checking the installation..."
-validation=$(which -x fail2ban-client)
+validation=$(which fail2ban-client)
 if [ ! -z "${validation}" ]; then
   echo
   echo -e "\\e[32mInstallation done.\\e[0m"


### PR DESCRIPTION
## Description:
Adds a installation script of the [fail2ban](https://github.com/fail2ban/fail2ban) service.

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [x] Script has validation check of the job.
  - [x] Created/Updated documentation at `/docs`
