### PR TITLE
Fix broken link to fail2ban-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ below for usage and instructions.
   - [AppDaemon](/docs/appdaemon.md)
   - [Cloud9](/docs/cloud9.md)
   - [Duck DNS](/docs/duckdns.md)
-  - [Fail2ban](/docs/fail2fail2ban.md)
+  - [Fail2ban](/docs/fail2ban.md)
   - [Hassbian](/docs/hassbian.md)
   - [Home Assistant](/docs/homeassistant.md)
   - [Homebridge](/docs/homebridge.md)


### PR DESCRIPTION
## Description:

This fixes a broken link in README.md. No code changes.

**Related issue (if applicable):** No related Issue.

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [x] Created/Updated documentation at `/docs`
