### PR TITLE
homeassistant: Move pip3 to python3 -m pip

### DIFF
--- a/package/opt/hassbian/suites/homeassistant.sh
+++ b/package/opt/hassbian/suites/homeassistant.sh
@@ -22,8 +22,8 @@ echo "Changing to Home Assistant venv"
 source /srv/homeassistant/bin/activate
 
 echo "Installing latest version of Home Assistant"
-pip3 install setuptools wheel
-pip3 install homeassistant
+python3 -m pip install setuptools wheel
+python3 -m pip install homeassistant
 
 echo "Deactivating virtualenv"
 deactivate
@@ -91,7 +91,7 @@ else
   fi
   sudo -u homeassistant -H /bin/bash << EOF | grep Version | awk '{print $2}'|while read -r version; do if [[ "${newversion}" == "${version}" ]]; then echo "You already have version: $version";exit 1;fi;done
   source /srv/homeassistant/bin/activate
-  pip3 show homeassistant
+  python3 -m pip show homeassistant
 EOF
 
   if [[ $? == 1 ]]; then
@@ -107,13 +107,13 @@ echo "Changing to Home Assistant venv"
 source /srv/homeassistant/bin/activate
 
 echo "Upgrading Home Assistant"
-pip3 install --upgrade setuptools wheel
+python3 -m pip install --upgrade setuptools wheel
 if [ "$DEV" == "true" ]; then
-  pip3 install git+https://github.com/home-assistant/home-assistant@dev
+  python3 -m pip install git+https://github.com/home-assistant/home-assistant@dev
 elif [ "$BETA" == "true" ]; then
-  pip3 install --upgrade --pre homeassistant
+  python3 -m pip install --upgrade --pre homeassistant
 else
-  pip3 install --upgrade homeassistant=="$newversion"
+  python3 -m pip install --upgrade homeassistant=="$newversion"
 fi
 
 echo "Deactivating virtualenv"
@@ -141,7 +141,7 @@ EOF
     if [ "$RESPONSE" == "y" ] || [ "$RESPONSE" == "Y" ]; then
       sudo -u homeassistant -H /bin/bash << EOF
       source /srv/homeassistant/bin/activate
-      pip3 install --upgrade homeassistant=="$current_version"
+      python3 -m pip install --upgrade homeassistant=="$current_version"
       deactivate
 EOF
     fi


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>
There was a user that got this installed by using this variant.
<https://discordapp.com/channels/330944238910963714/332318336111214602/510581880031019038>
There was a permission issue as well, but I think that was due to trying to get it working other ways.

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
