### PR TITLE
Homeassistant:  Use 2 lines instead of 1 line for config check.

### DIFF
--- a/package/opt/hassbian/suites/homeassistant.sh
+++ b/package/opt/hassbian/suites/homeassistant.sh
@@ -128,7 +128,7 @@ if [ "$FORCE" != "true"  ]; then
 EOF
   )
   config_check_lines=$(echo "$config_check" | wc -l)
-  if (( config_check_lines > 1 ));then
+  if (( config_check_lines > 2 ));then
     if [ "$ACCEPT" != "true" ]; then
       echo -n "Config check failed for new version, do you want to revert? [Y/n] : "
       read -r RESPONSE


### PR DESCRIPTION
## Description:

There is an issue with HA that prints an extra line for the config check every time, resulting in wrong results.

```bash
(homeassistant) homeassistant@hassbian:/home/pi $  hass --script check_config -c /home/homeassistant/.homeassistant/
INFO:homeassistant.util.package:Attempting install of colorlog==3.1.4
Testing configuration at /home/homeassistant/.homeassistant/
```

<!-- **Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here> -->

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)
<!--
### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs` -->
