### PR TITLE
Homeassistant: Set permissions before install.

### DIFF
--- a/package/opt/hassbian/suites/homeassistant.sh
+++ b/package/opt/hassbian/suites/homeassistant.sh
@@ -12,6 +12,9 @@ function homeassistant-show-copyright-info {
 }
 
 function homeassistant-install-package {
+echo "Setting correct premissions"
+chown homeassistant:homeassistant -R /srv/homeassistant
+
 echo "Changing to the homeassistant user"
 sudo -u homeassistant -H /bin/bash << EOF
 
@@ -99,6 +102,9 @@ EOF
     exit 1
   fi
 fi
+
+echo "Setting correct premissions"
+chown homeassistant:homeassistant -R /srv/homeassistant
 
 echo "Changing to the homeassistant user"
 sudo -u homeassistant -H /bin/bash << EOF


### PR DESCRIPTION
## Description:
The install_homeassistant.service now upgrades `hassbian-scripts` on first boot if there is an update, resulting in `/srv/homeassistant` being owned by root.

From first boot:

```bash
pi@hassbian:~ $ ls -ld /srv/homeassistant
drwxr-xr-x 3 root root 4096 Nov 12 22:11 /srv/homeassistant
```

And in `journalctl`

```
Nov 12 22:11:30 hassbian hassbian-config[1223]: Changing to the homeassistant user
Nov 12 22:11:30 hassbian hassbian-config[1223]: Creating Home Assistant venv
Nov 12 22:11:31 hassbian hassbian-config[1223]: Error: [Errno 13] Permission denied: '/srv/homeassistant/include'
Nov 12 22:11:31 hassbian hassbian-config[1223]: Changing to Home Assistant venv
Nov 12 22:11:31 hassbian hassbian-config[1223]: /bin/bash: line 6: /srv/homeassistant/bin/activate: No such file or directory
```
By explicit setting permissions before the install starts this will be corrected.
Added it to the upgrade script to for good measure.

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)
<!--
### If pertinent:
  - [x] Script has validation check of the job.
  - [x] Created/Updated documentation at `/docs` -->
