### PR TITLE
Fixed example

### DIFF
--- a/docs/postgresql.md
+++ b/docs/postgresql.md
@@ -21,7 +21,7 @@ If so, add a PR here when you are done:
 Example of how to create the database:
 
 ```bash
-sudo -u postgres
+sudo -s -u postgres
 createuser homeassistant
 createdb -O homeassistant homeassistant
 ```


### PR DESCRIPTION
## Description:
Sudo command was missing `-s` flag.

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)