### PR TITLE
Added server_port directive to Duck DNS Hassbian configuration for SSL

### DIFF
--- a/docs/duckdns.md
+++ b/docs/duckdns.md
@@ -1,7 +1,7 @@
 # Duck DNS
 
 This script adds a cron job which auto updates the WAN IP address for the
-defined domain.  
+defined domain.
 Before running this script you should already have a
 [Duck DNS account][duckdns]. During the installation you will be asked to
 supply your domain name and the token for your account.
@@ -19,7 +19,7 @@ sudo hassbian-config remove duckdns
 
 ## Additional info
 
-Running as: `homeassistant`  
+Running as: `homeassistant`
 
 If you choose to also generate SSL certificates with this you would need to
 add this under `http:` to your `configuration.yaml`
@@ -27,7 +27,8 @@ add this under `http:` to your `configuration.yaml`
 ```yaml
   ssl_certificate: /home/homeassistant/dehydrated/certs/YOURDOMAIN.duckdns.org/fullchain.pem
   ssl_key: /home/homeassistant/dehydrated/certs/YOURDOMAIN.duckdns.org/privkey.pem
-  base_url: YOURDOMAIN.duckdns.org:PORTNUMBER
+  base_url: YOURDOMAIN.duckdns.org
+  server_port: PORTNUMBER
 ```
 
 Keep in mind that after you added the ssl keys to your config and restarted Home Assistant, your installation won't be available through http anymore but then only through https.


### PR DESCRIPTION
## Description:

Update Hassbian documentation to reflect need for server_port configuration when setting up SSL. 

Refer to https://community.home-assistant.io/t/duckdns-and-ssl-problem-ssl-error-rx-record-too-long/48820

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [X] The code change is tested and works locally.
  - [X] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [X] Created/Updated documentation at `/docs`
