### PR TITLE
Throw error if running user is not root

### DIFF
--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -255,6 +255,12 @@ function show-installed-suites {
   return 0
 }
 
+if (( $EUID != 0 ))
+then
+  echo "Error: hassbian-config must be as root (with sudo)"
+  exit 1
+fi
+
 if [ $# -lt 1 ]; then
   usage
   exit 0


### PR DESCRIPTION
This change just checks is the running user is root. I found it while going through my repositories.