### PR TITLE
Set timeout value

### DIFF
--- a/package/etc/systemd/system/install_homeassistant.service
+++ b/package/etc/systemd/system/install_homeassistant.service
@@ -9,6 +9,7 @@ After=network.target
 [Service]
 ExecStartPre=/usr/local/bin/hassbian-config upgrade hassbian-script
 ExecStart=/usr/local/bin/hassbian-config install homeassistant --force
+TimeOutSec=1800
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description:

`install_homeassistant.service` upgrades `hassbian-config` and installs `homeassistant`
The default value of 60s is not enough and this fails.

Multiple users have reported this on discord and the forums.

**Related issue (if applicable):** 
Fixes #N/A

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [x] Script has validation check of the job.
  - [x] Created/Updated documentation at `/docs`
