### PR TITLE
Adds hassbian manager script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ below for usage and instructions.
   - [Homebridge](/docs/homebridge.md)
   - [HUE](/docs/hue.md)
   - [LibCEC](/docs/libcec.md)
+  - [Manager](/docs/manager.md)
   - [MariaDB](/docs/mariadb.md)
   - [Monitor](/docs/monitor.md)
   - [Mosquitto](/docs/mosquitto.md)

--- a/docs/manager.md
+++ b/docs/manager.md
@@ -1,0 +1,38 @@
+# Hassbian manager
+
+Hassbian manager is a web UI tool that can help you manage your suites.
+
+## Installation
+
+```bash
+sudo hassbian-config install manager
+```
+
+## Upgrade
+
+```bash
+sudo hassbian-config upgrade manager
+```
+
+## Remove to beta channel
+
+```bash
+sudo hassbian-config remoev manager
+```
+
+## Additional info
+
+Description | Command/value
+:--- | :---
+Running as: | homeassistant
+Start service: | `sudo systemctl start hassbian-manager@homeassistant.service`
+Stop service: | `sudo systemctl stop hassbian-manager@homeassistant.service`
+Restart service: | `sudo systemctl restart hassbian-manager@homeassistant.service`
+Service status: | `sudo systemctl status hassbian-manager@homeassistant.service`
+
+***
+
+The script was originally contributed by [@Ludeeus][ludeeus].
+
+<!--- Links --->
+[ludeeus]: https://github.com/ludeeus

--- a/docs/manager.md
+++ b/docs/manager.md
@@ -27,6 +27,9 @@ sudo hassbian-config remoev manager
 Description | Command/value
 :--- | :---
 Running as: | homeassistant
+Default user: | `pi`
+Default password: | `raspberry`
+Port: | `9999`
 Start service: | `sudo systemctl start hassbian-manager@homeassistant.service`
 Stop service: | `sudo systemctl stop hassbian-manager@homeassistant.service`
 Restart service: | `sudo systemctl restart hassbian-manager@homeassistant.service`

--- a/docs/manager.md
+++ b/docs/manager.md
@@ -2,6 +2,8 @@
 
 Hassbian manager is a web UI tool that can help you manage your suites.
 
+When installed the WEB UI are running on port `9999`
+
 ## Installation
 
 ```bash

--- a/package/opt/hassbian/suites/files/hassbian-manager@homeassistant.service
+++ b/package/opt/hassbian/suites/files/hassbian-manager@homeassistant.service
@@ -1,0 +1,16 @@
+#
+# Service file for systems with systemd to run Hassbian manager as the homeassistant user.
+#
+
+[Unit]
+Description=Hassbian manager for %i
+After=network.target
+
+[Service]
+Type=simple
+User=%i
+ExecStart=/usr/local/bin/pyhassbian
+SendSIGKILL=no
+
+[Install]
+WantedBy=multi-user.target

--- a/package/opt/hassbian/suites/files/hassbian-manager@homeassistant.service
+++ b/package/opt/hassbian/suites/files/hassbian-manager@homeassistant.service
@@ -9,7 +9,7 @@ After=network.target
 [Service]
 Type=simple
 User=%i
-ExecStart=/usr/local/bin/pyhassbian
+ExecStart=/usr/local/bin/pyhassbian --username %%USERNAME%% --password %%PASSWORD%%
 SendSIGKILL=no
 
 [Install]

--- a/package/opt/hassbian/suites/manager.sh
+++ b/package/opt/hassbian/suites/manager.sh
@@ -74,7 +74,7 @@ systemctl disable hassbian-manager@homeassistant.service
 rm /etc/systemd/system/hassbian-manager@homeassistant.service
 sync
 
-echo "Upgrading Hassbian manager"
+echo "Removing Hassbian manager"
 python3 -m pip uninstall pyhassbian
 
 printf "\\e[32mRemoval done..\\e[0m\\n"

--- a/package/opt/hassbian/suites/manager.sh
+++ b/package/opt/hassbian/suites/manager.sh
@@ -101,7 +101,7 @@ rm /etc/systemd/system/hassbian-manager@homeassistant.service
 sync
 
 echo "Removing Hassbian manager"
-python3 -m pip uninstall pyhassbian
+python3 -m pip uninstall --yes pyhassbian
 
 printf "\\e[32mRemoval done..\\e[0m\\n"
 }

--- a/package/opt/hassbian/suites/manager.sh
+++ b/package/opt/hassbian/suites/manager.sh
@@ -12,9 +12,6 @@ function manager-show-copyright-info {
 }
 
 function manager-install-package {
-echo "Setting correct premissions"
-chown homeassistant:homeassistant -R /srv/homeassistant
-
 
 echo "Installing latest version of Hassbian manager"
 python3 -m pip install setuptools wheel

--- a/package/opt/hassbian/suites/manager.sh
+++ b/package/opt/hassbian/suites/manager.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+function manager-show-short-info {
+  echo "Hassbian manager script."
+}
+
+function manager-show-long-info {
+  echo "Hassbian manager is a web UI tool that can help you manage your suites."
+}
+
+function manager-show-copyright-info {
+  echo "Original concept by Ludeeus <https://github.com/ludeeus>."
+}
+
+function manager-install-package {
+echo "Setting correct premissions"
+chown homeassistant:homeassistant -R /srv/homeassistant
+
+
+echo "Installing latest version of Hassbian manager"
+python3 -m pip install setuptools wheel
+python3 -m pip install pyhassbian
+
+
+echo "Enabling Hassbian manager service"
+cp /opt/hassbian/suites/files/hassbian-manager@homeassistant.service /etc/systemd/system/hassbian-manager@homeassistant.service
+systemctl enable hassbian-manager@homeassistant.service
+sync
+
+echo "Starting Hassbian manager"
+systemctl start hassbian-manager@homeassistant.service
+
+ip_address=$(ifconfig | grep "inet.*broadcast" | grep -v 0.0.0.0 | awk '{print $2}')
+
+echo "Checking the installation..."
+validation=$(pgrep -x pyhassbian)
+if [ ! -z "${validation}" ]; then
+  echo
+  echo -e "\\e[32mInstallation done..\\e[0m"
+  echo "Hassbian manager installation is running at $ip_address:9999 or if preferred http://hassbian.local:9999"
+  echo
+  echo
+else
+  echo
+  echo -e "\\e[31mInstallation failed..."
+  echo
+  return 1
+fi
+return 0
+}
+
+function manager-upgrade-package {
+echo "Upgrading Hassbian manager"
+python3 -m pip install --upgrade pyhassbian
+
+echo "Restarting Hassbian manager"
+systemctl start hassbian-manager@homeassistant.service
+
+echo "Checking the installation..."
+validation=$(pgrep -x pyhassbian)
+if [ ! -z "${validation}" ]; then
+  echo
+  echo -e "\\e[32mUpgrade script completed..\\e[0m"
+  echo
+else
+  echo
+  echo -e "\\e[31mUpgrade failed..."
+  echo
+  return 1
+fi
+return 0
+}
+
+function manager-remove-package {
+printf "Removing Hassbian manager...\\n"
+systemctl stop hassbian-manager@homeassistant.service
+systemctl disable hassbian-manager@homeassistant.service
+rm /etc/systemd/system/hassbian-manager@homeassistant.service
+sync
+
+echo "Upgrading Hassbian manager"
+python3 -m pip uninstall pyhassbian
+
+printf "\\e[32mRemoval done..\\e[0m\\n"
+}
+
+[[ "$_" == "$0" ]] && echo "hassbian-config helper script; do not run directly, use hassbian-config instead"

--- a/package/opt/hassbian/suites/manager.sh
+++ b/package/opt/hassbian/suites/manager.sh
@@ -13,6 +13,28 @@ function manager-show-copyright-info {
 
 function manager-install-package {
 
+if [ "$ACCEPT" == "true" ]; then
+  username=pi
+  password=raspberry
+else
+  echo
+  echo "Please take a moment to setup your the user account"
+  echo
+
+  echo -n "Username: "
+  read -r username
+  if [ ! "$username" ]; then
+    username=pi
+  fi
+
+  echo -n "Password: "
+  read -s -r password
+  echo
+  if [ ! "$password" ]; then
+    password=raspberry
+  fi
+fi
+
 echo "Installing latest version of Hassbian manager"
 python3 -m pip install setuptools wheel
 python3 -m pip install pyhassbian
@@ -20,6 +42,10 @@ python3 -m pip install pyhassbian
 
 echo "Enabling Hassbian manager service"
 cp /opt/hassbian/suites/files/hassbian-manager@homeassistant.service /etc/systemd/system/hassbian-manager@homeassistant.service
+
+sed -i "s,%%USERNAME%%,${username},g" /etc/systemd/system/hassbian-manager@homeassistant.service
+sed -i "s,%%PASSWORD%%,${password},g" /etc/systemd/system/hassbian-manager@homeassistant.service
+
 systemctl enable hassbian-manager@homeassistant.service
 sync
 


### PR DESCRIPTION
## Description:

This adds a "Hassbian manager" web tool to manage hassbian-config suites.
[![Image from Gyazo](https://i.gyazo.com/5ae526559e7a19ceef97621b741647de.gif)](https://gyazo.com/5ae526559e7a19ceef97621b741647de)


<!-- **Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here> -->

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [x] Script has validation check of the job.
  - [x] Created/Updated documentation at `/docs`
