### PR TITLE
Fix remove permissions for homeassistant user

### DIFF
--- a/package/etc/sudoers.d/020_homeassistant_hassbian-scripts
+++ b/package/etc/sudoers.d/020_homeassistant_hassbian-scripts
@@ -1,4 +1,4 @@
 %homeassistant ALL= NOPASSWD: /usr/local/bin/hassbian-config show *
 %homeassistant ALL= NOPASSWD: /usr/local/bin/hassbian-config install *
 %homeassistant ALL= NOPASSWD: /usr/local/bin/hassbian-config upgrade *
-
+%homeassistant ALL= NOPASSWD: /usr/local/bin/hassbian-config remove *


### PR DESCRIPTION
## Description:

Adds remove to sudoers file

<!-- **Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here> -->

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)
<!--
### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
-->