### PR TITLE
Remove controlfile when removing suite

### DIFF
--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -183,7 +183,11 @@ function run-suite { #This is the function the actually run install/upgrade.
   RETURN=("$?") # Return value after script execution.
   if [ "$DEBUG" == "true" ]; then set +x; fi #Deactivating debug if --debug is used.
   if [ "$RETURN" == "0" ]; then STATE="installed"; else printf "\\e[0mIf you have issues with this script, please say something in the #devs_hassbian channel on Discord.\\n" && STATE="failed"; fi #Set suite state to installed if 0 is returned, failed otherwise.
-  echo "SCRIPTSTATE=$STATE" > "$SUITE_CONTROL_DIR/$2" #Setting status in control file.
+  if [ "$1" == "remove" ]; then 
+    rm "$SUITE_CONTROL_DIR/$2"
+  else
+    echo "SCRIPTSTATE=$STATE" > "$SUITE_CONTROL_DIR/$2" #Setting status in control file.
+  fi
   return 0
 }
 


### PR DESCRIPTION
## Description:

If the run action is `remove` remove the controlfile.
 <!--
**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>
-->
## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)
<!--
### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
--<