### PR TITLE
cloud9: Add npm install to c9 script to make sure all packages are installed.

### DIFF
--- a/package/opt/hassbian/suites/cloud9.sh
+++ b/package/opt/hassbian/suites/cloud9.sh
@@ -24,6 +24,9 @@ echo "Creating installation directory..."
 mkdir /opt/c9sdk
 chown homeassistant:homeassistant /opt/c9sdk
 
+echo "Installing npm"
+apt isntall -y npm
+
 echo "Changing to the homeassistant user"
 sudo -u homeassistant -H /bin/bash << EOF
   printf "Downloading and installing Cloud9 SDK...\\n"
@@ -36,6 +39,9 @@ sudo -u homeassistant -H /bin/bash << EOF
   echo "Symlinking /home/homeassistant/.homeassistant to the workspace."
   ln -s /home/homeassistant/.homeassistant/ /home/homeassistant/c9workspace/homeassistant
 EOF
+
+cd /opt/c9sdk || exit |
+npm install
 
 echo "Copying Cloud9 service file..."
 cp /opt/hassbian/suites/files/cloud9.service /etc/systemd/system/cloud9@homeassistant.service

--- a/package/opt/hassbian/suites/cloud9.sh
+++ b/package/opt/hassbian/suites/cloud9.sh
@@ -24,9 +24,6 @@ echo "Creating installation directory..."
 mkdir /opt/c9sdk
 chown homeassistant:homeassistant /opt/c9sdk
 
-echo "Installing npm"
-apt install -y npm
-
 echo "Changing to the homeassistant user"
 sudo -u homeassistant -H /bin/bash << EOF
   printf "Downloading and installing Cloud9 SDK...\\n"
@@ -40,9 +37,6 @@ sudo -u homeassistant -H /bin/bash << EOF
   ln -s /home/homeassistant/.homeassistant/ /home/homeassistant/c9workspace/homeassistant
 EOF
 
-cd /opt/c9sdk || exit 1
-npm install
-
 echo "Copying Cloud9 service file..."
 cp /opt/hassbian/suites/files/cloud9.service /etc/systemd/system/cloud9@homeassistant.service
 
@@ -54,9 +48,23 @@ echo "Starting Cloud9 service..."
 systemctl start cloud9@homeassistant.service
 
 echo "Checking the installation..."
-ip_address=$(ifconfig | grep "inet.*broadcast" | grep -v 0.0.0.0 | awk '{print $2}')
+sleep 15
 validation=$(pgrep -f cloud9)
 if [ ! -z "${validation}" ]; then
+  echo "Using fallback installation."
+  echo "Installing npm"
+  apt install -y npm
+
+  cd /opt/c9sdk || exit 1
+  npm install
+
+  echo "Checking the installation..."
+  sleep 15
+fi
+
+validation=$(pgrep -f cloud9)
+if [ -z "${validation}" ]; then
+  ip_address=$(ifconfig | grep "inet.*broadcast" | grep -v 0.0.0.0 | awk '{print $2}')
   echo
   echo -e "\\e[32mInstallation done.\\e[0m"
   echo "Your Cloud9 IDE is now avaiable at http://$ip_address:8181"
@@ -83,6 +91,7 @@ printf "Starting Cloud9 service...\\n"
 systemctl start cloud9@homeassistant.service
 
 echo "Checking the installation..."
+sleep 15
 validation=$(pgrep -f cloud9)
 if [ ! -z "${validation}" ]; then
   echo

--- a/package/opt/hassbian/suites/cloud9.sh
+++ b/package/opt/hassbian/suites/cloud9.sh
@@ -40,7 +40,7 @@ sudo -u homeassistant -H /bin/bash << EOF
   ln -s /home/homeassistant/.homeassistant/ /home/homeassistant/c9workspace/homeassistant
 EOF
 
-cd /opt/c9sdk || exit |
+cd /opt/c9sdk || exit 1
 npm install
 
 echo "Copying Cloud9 service file..."

--- a/package/opt/hassbian/suites/cloud9.sh
+++ b/package/opt/hassbian/suites/cloud9.sh
@@ -25,7 +25,7 @@ mkdir /opt/c9sdk
 chown homeassistant:homeassistant /opt/c9sdk
 
 echo "Installing npm"
-apt isntall -y npm
+apt install -y npm
 
 echo "Changing to the homeassistant user"
 sudo -u homeassistant -H /bin/bash << EOF


### PR DESCRIPTION
## Description:

Adds an extra `npm install` to the install script.

**Related issue (if applicable):** Fixes #226 

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)
<!--
### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
-->