### PR TITLE
Add autocomplete for remove

### DIFF
--- a/package/etc/bash_completion.d/hassbian-config
+++ b/package/etc/bash_completion.d/hassbian-config
@@ -14,7 +14,7 @@ _hassbian-config()
     fi
 
     case "${prev}" in
-    install|upgrade|show)
+    install|upgrade|show|remove)
     COMPREPLY=( $(compgen -W "${inst}" -- ${cur}) )
     return 0
     ;;


### PR DESCRIPTION
## Description:

Adds `remove` to bash_completion.
<!--
**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>
-->
## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)
<!--
### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
-->