### PR TITLE
Cloud9: Adds authentication

### DIFF
--- a/docs/cloud9.md
+++ b/docs/cloud9.md
@@ -28,6 +28,8 @@ Description | Command/value
 Running as: | homeassistant
 Default workspace: | /home/homeassistant/c9workspace/
 Default port: | 8181
+Default user: | `pi`
+Default password: | `raspberry`
 Start service: | `sudo systemctl start cloud9@homeassistant.service`
 Stop service: | `sudo systemctl stop cloud9@homeassistant.service`
 Restart service: | `sudo systemctl restart cloud9@homeassistant.service`

--- a/package/opt/hassbian/suites/cloud9.sh
+++ b/package/opt/hassbian/suites/cloud9.sh
@@ -13,6 +13,29 @@ function cloud9-show-copyright-info {
 }
 
 function cloud9-install-package {
+
+if [ "$ACCEPT" == "true" ]; then
+  username=pi
+  password=raspberry
+else
+  echo
+  echo "Please take a moment to setup your the user account"
+  echo
+
+  echo -n "Username: "
+  read -r username
+  if [ ! "$username" ]; then
+    username=pi
+  fi
+
+  echo -n "Password: "
+  read -s -r password
+  echo
+  if [ ! "$password" ]; then
+    password=raspberry
+  fi
+fi
+
 node=$(which node)
 if [ -z "${node}" ]; then #Installing NodeJS if not already installed.
   printf "Downloading and installing NodeJS...\\n"
@@ -39,6 +62,9 @@ EOF
 
 echo "Copying Cloud9 service file..."
 cp /opt/hassbian/suites/files/cloud9.service /etc/systemd/system/cloud9@homeassistant.service
+
+sed -i "s,%%USERNAME%%,${username},g" /etc/systemd/system/cloud9@homeassistant.service
+sed -i "s,%%PASSWORD%%,${password},g" /etc/systemd/system/cloud9@homeassistant.service
 
 echo "Enabling Cloud9 service..."
 systemctl enable cloud9@homeassistant.service

--- a/package/opt/hassbian/suites/files/cloud9.service
+++ b/package/opt/hassbian/suites/files/cloud9.service
@@ -4,6 +4,6 @@ After=network-online.target
 [Service]
 Type=simple
 User=homeassistant
-ExecStart=/opt/c9sdk/server.js -l 0.0.0.0 -a : -w /home/homeassistant/c9workspace
+ExecStart=/opt/c9sdk/server.js -l 0.0.0.0 -a %%USERNAME%%:%%PASSWORD%% -w /home/homeassistant/c9workspace
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description:

Adds authentication to Cloud9.

**Related issue (if applicable):**  
_Does not fix #250 (existing), but it will for new installations._

## Checklist (Required):
  - [ ] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [x] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
