### PR TITLE
Change discord channel name in "error" messages.

### DIFF
--- a/package/usr/local/bin/hassbian-config
+++ b/package/usr/local/bin/hassbian-config
@@ -182,7 +182,7 @@ function run-suite { #This is the function the actually run install/upgrade.
   "$2"-"$1"-package #Running the script function install/upgrade SUITE.
   RETURN=("$?") # Return value after script execution.
   if [ "$DEBUG" == "true" ]; then set +x; fi #Deactivating debug if --debug is used.
-  if [ "$RETURN" == "0" ]; then STATE="installed"; else printf "\\e[0mIf you have issues with this script, please say something in the #devs_hassbian channel on Discord.\\n" && STATE="failed"; fi #Set suite state to installed if 0 is returned, failed otherwise.
+  if [ "$RETURN" == "0" ]; then STATE="installed"; else printf "\\e[0mIf you have issues with this script, please say something in the #hassbian channel on Discord.\\n" && STATE="failed"; fi #Set suite state to installed if 0 is returned, failed otherwise.
   if [ "$1" == "remove" ]; then 
     rm "$SUITE_CONTROL_DIR/$2"
   else


### PR DESCRIPTION
## Description:

Changes the printed channel name from `#devs_hassbian` (development) to `#hassbian` (support)

<!--
**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>
-->
## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)
<!--
### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
-->