### PR TITLE
Add c_rehash to installation script

### DIFF
--- a/package/opt/hassbian/suites/homeassistant.sh
+++ b/package/opt/hassbian/suites/homeassistant.sh
@@ -12,6 +12,9 @@ function homeassistant-show-copyright-info {
 }
 
 function homeassistant-install-package {
+echo "Checking generation of local certificates "
+c_rehash
+
 echo "Setting correct premissions"
 chown homeassistant:homeassistant -R /srv/homeassistant
 


### PR DESCRIPTION
## Description:
Runs the `c_rehash` command before installation to verify that local certificates are available.

**Related issue (if applicable):** Fixes #254 (Second comment)

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)
