### PR TITLE
Remove mention of Google Home from component

### DIFF
--- a/docs/hue.md
+++ b/docs/hue.md
@@ -1,7 +1,7 @@
 # Hue
 
 Configures the Python executable to allow usage of low numbered port numbers
-for use with Amazon Echo, Google Home and Mycroft.ai.
+for use with Amazon Echo or Mycroft.ai.
 
 ## Installation
 

--- a/package/opt/hassbian/suites/hue.sh
+++ b/package/opt/hassbian/suites/hue.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 function hue-show-short-info {
-  echo "Echo/Home/Mycroft Emulated Hue install script for Hassbian."
+  echo "Echo/Mycroft Emulated Hue install script for Hassbian."
 }
 
 function hue-show-long-info {
   echo "Configures the Python executable to allow usage of low numbered"
-  echo "ports for use with Amazon Echo, Google Home and Mycroft.ai."
+  echo "ports for use with Amazon Echo or Mycroft.ai."
 }
 
 function hue-show-copyright-info {


### PR DESCRIPTION
## Description:
> Be aware that emulated_hue doesn’t work for new Google Home users. If you’re a new user of Google Home, use the Google Assistant component.
 - https://www.home-assistant.io/components/emulated_hue/

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [x] Created/Updated documentation at `/docs`
