### PR TITLE
Pause After Service Start During Upgrade

### DIFF
--- a/package/opt/hassbian/suites/homeassistant.sh
+++ b/package/opt/hassbian/suites/homeassistant.sh
@@ -162,10 +162,9 @@ echo "Restarting Home Assistant"
 systemctl restart home-assistant@homeassistant.service
 
 echo "Waiting for Home Assistant to start"
-for i in 1 2 3 4 5
+for i in {1..5}
 do
-    sleep 1
-
+    sleep 1s
     if [ $(systemctl is-active home-assistant@homeassistant.service) == "active" ]; then
         break
     fi

--- a/package/opt/hassbian/suites/homeassistant.sh
+++ b/package/opt/hassbian/suites/homeassistant.sh
@@ -161,6 +161,16 @@ fi
 echo "Restarting Home Assistant"
 systemctl restart home-assistant@homeassistant.service
 
+echo "Waiting for Home Assistant to start"
+for i in 1 2 3 4 5
+do
+    sleep 1
+
+    if [ $(systemctl is-active home-assistant@homeassistant.service) == "active" ]; then
+        break
+    fi
+done
+
 echo "Checking the installation..."
 validation=$(pgrep -x hass)
 if [ ! -z "${validation}" ]; then


### PR DESCRIPTION
## Description:

Fix erroneous "Upgrade Failed" message by adding a pause after restarting the service to make sure the "pgrep -x hass" has time to get a Process ID

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
