### PR TITLE
Service: Use correct TimeoutSec option.

### DIFF
--- a/package/etc/systemd/system/install_homeassistant.service
+++ b/package/etc/systemd/system/install_homeassistant.service
@@ -9,7 +9,7 @@ After=network.target
 [Service]
 ExecStartPre=/usr/local/bin/hassbian-config upgrade hassbian-script
 ExecStart=/usr/local/bin/hassbian-config install homeassistant --force
-TimeoutSec=1800
+TimeoutSec=3600
 
 [Install]
 WantedBy=multi-user.target

--- a/package/etc/systemd/system/install_homeassistant.service
+++ b/package/etc/systemd/system/install_homeassistant.service
@@ -9,7 +9,7 @@ After=network.target
 [Service]
 ExecStartPre=/usr/local/bin/hassbian-config upgrade hassbian-script
 ExecStart=/usr/local/bin/hassbian-config install homeassistant --force
-TimeOutSec=1800
+TimeoutSec=1800
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description:

`TimeOutSec` is not valid, it needs to be `TimeoutSec`

This is with the 1.6 image:

```bash
pi@hassbian:~ $ sudo journalctl | grep TimeOutSec
Apr 14 17:39:29 hassbian systemd[1]: /etc/systemd/system/install_homeassistant.service:7: Unknown lvalue 'TimeOutSec' in section 'Service', ignoring
```

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [x] The code change is tested and works locally.
<!--  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
-->