### PR TITLE
Mosquitto: Force stretch repo

### DIFF
--- a/package/opt/hassbian/suites/mosquitto.sh
+++ b/package/opt/hassbian/suites/mosquitto.sh
@@ -51,10 +51,9 @@ echo "Installing repository key"
 wget -O - http://repo.mosquitto.org/debian/mosquitto-repo.gpg.key | apt-key add -
 
 echo "Adding repository"
-OS_VERSION=$(lsb_release -cs)
-if [ ! -f /etc/apt/sources.list.d/mosquitto-"$OS_VERSION".list ]
+if [ ! -f /etc/apt/sources.list.d/mosquitto-stretch.list ]
 then
-  curl -o /etc/apt/sources.list.d/mosquitto-"$OS_VERSION".list http://repo.mosquitto.org/debian/mosquitto-"$OS_VERSION".list
+  curl -o /etc/apt/sources.list.d/mosquitto-stretch.list http://repo.mosquitto.org/debian/mosquitto-stretch.list
 else
   echo "Already present, skipping..."
 fi


### PR DESCRIPTION
## Description:

Forces usage of the `stretch`  repo for mosquitto, currently there is no repo for `buster`

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [x] The code change is tested and works locally.
<!--  - [ ] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
-->