### PR TITLE
hassbian-script: Use osrelease to select stretch/buster

### DIFF
--- a/package/opt/hassbian/suites/hassbian-script.sh
+++ b/package/opt/hassbian/suites/hassbian-script.sh
@@ -25,8 +25,11 @@ if [ "$DEV" == "true"  ]; then
     return 0
   fi
 fi
+
+OSRELEASE=$(lsb_release -cs)
+
 echo "Updating apt information..."
-echo "deb [trusted=yes] https://gitlab.com/hassbian/repository$devbranch/raw/master stretch main" | tee /etc/apt/sources.list.d/hassbian.list
+echo "deb [trusted=yes] https://gitlab.com/hassbian/repository$devbranch/raw/master $OSRELEASE main" | tee /etc/apt/sources.list.d/hassbian.list
 apt update
 
 echo "Checking installed version..."
@@ -37,7 +40,7 @@ if [ "$current_version" != "installed" ]; then
   apt clean
 
   echo "Installing newest version of hassbian-scripts..."
-  echo "deb [trusted=yes] https://gitlab.com/hassbian/repository$devbranch/raw/master stretch main" | tee /etc/apt/sources.list.d/hassbian.list
+  echo "deb [trusted=yes] https://gitlab.com/hassbian/repository$devbranch/raw/master $OSRELEASE main" | tee /etc/apt/sources.list.d/hassbian.list
   apt update
   apt install -y hassbian-scripts
 else


### PR DESCRIPTION
## Description:

Use osrelease var to select stretch/buster.
Changes have been added to the build script to match this.

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [x] The code change is tested and works locally.
<!--  - [ ] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
-->