### PR TITLE
mariadb: Adds default-libmysqlclient-dev

### DIFF
--- a/package/opt/hassbian/suites/mariadb.sh
+++ b/package/opt/hassbian/suites/mariadb.sh
@@ -15,7 +15,7 @@ function mariadb-show-copyright-info {
 function mariadb-install-package {
 echo "Running apt-get preparation"
 apt-get update
-apt-get install -y mariadb-server libmariadbclient-dev
+apt-get install -y mariadb-server libmariadbclient-dev default-libmysqlclient-dev
 
 echo "Changing to homeassistant user"
 sudo -u homeassistant -H /bin/bash <<EOF


### PR DESCRIPTION
## Description:

Adds default-libmysqlclient-dev to fix this error during installation of the python package:

```bash
    Complete output from command python setup.py egg_info:
    /bin/sh: 1: mysql_config: not found
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-vipuxr5a/mysqlclient/setup.py", line 16, in <module>
        metadata, options = get_config()
      File "/tmp/pip-install-vipuxr5a/mysqlclient/setup_posix.py", line 51, in get_config
        libs = mysql_config("libs")
      File "/tmp/pip-install-vipuxr5a/mysqlclient/setup_posix.py", line 29, in mysql_config
        raise EnvironmentError("%s not found" % (_mysql_config_path,))
    OSError: mysql_config not found

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-vipuxr5a/mysqlclient/
```

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [x] The code change is tested and works locally.
<!--  - [ ] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
-->