### PR TITLE
PostgreSQL: Use version 11 on newer images

### DIFF
--- a/package/opt/hassbian/suites/postgresql.sh
+++ b/package/opt/hassbian/suites/postgresql.sh
@@ -15,8 +15,12 @@ function postgresql-show-copyright-info {
 function postgresql-install-package {
 echo "Running apt-get preparation"
 apt-get update
-apt-get install -y postgresql-server-dev-9.6 postgresql-9.6
 
+if [ "$(lsb_release -cs)" == "stretch" ]; then
+  apt-get install -y postgresql-server-dev-9.6 postgresql-9.6
+else
+  apt-get install -y postgresql-server-dev-11 postgresql-11
+fi
 
 echo "Changing to homeassistant user"
 sudo -u homeassistant -H /bin/bash <<EOF


### PR DESCRIPTION
## Description:

Uses version 9.6 for stretch and version 11 for all others (newer)

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [x] The code change is tested and works locally.
<!--  - [ ] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)

### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
-->