### PR TITLE
Skip migration if osname is buster

### DIFF
--- a/package/opt/hassbian/suites/homeassistant/install
+++ b/package/opt/hassbian/suites/homeassistant/install
@@ -13,8 +13,10 @@ function install {
   c_rehash
     
   # Check if migration is needed.
-  source "$HASSBIAN_SUITE_DIR/homeassistant/python-migration"
-  python-migration true # 'true' forces the migration to run.
+  if [ "$(hassbian.info.version.osreleasename)" != "buster"  ]; then
+    source "$HASSBIAN_SUITE_DIR/homeassistant/python-migration"
+    python-migration true # 'true' forces the migration to run.
+  fi
 
   echo "Setting correct premissions"
   chown homeassistant:homeassistant -R "$HOME_ASSISTANT_VENV"


### PR DESCRIPTION
## Description:
Skips migration check during installation if `hassbian.info.version.osreleasename` returns "buster"

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)
<!-- 
### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
-->