### PR TITLE
Changes to the test suite and minor bugfixes.

### DIFF
--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -58,8 +58,8 @@ function hassbian.developer.test.package {
     ------------------------------------------
     "
     printf "\\e[36mTesting Suite: 'homeassistant'.................."
-    #test=$(hassbian-config install homeassistant --accept)
-    hassbian-config install homeassistant --accept
+    #test=$(hassbian-config install homeassistant --accept --ci)
+    hassbian-config install homeassistant --accept --ci
     if [ -z "$(echo $test | grep 'Operation failed...')" ];then
       ((pass+=1))
       printf "\\e[32mPASS(install)\\e[36m..."

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -54,6 +54,8 @@ function hassbian.developer.test.package {
 echo "$(hassbian.info.version.python)"
 which python
 which python3
+python3 -V
+
 
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     # Only try this if running in a CI env.

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -136,7 +136,7 @@ function hassbian.developer.test.package {
       if [ "$unattended" == "true" ];then
         # Install test...
         test=$(hassbian-config install "$suite" --accept)
-        if [ -z "${test | grep 'Operation failed...'}" ];then
+        if [ -z "$($test | grep 'Operation failed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(install)\\e[36m..."
         else
@@ -148,7 +148,7 @@ function hassbian.developer.test.package {
 
         # Upgrade test...
         test=$(hassbian-config upgrade "$suite" --accept)
-        if [ -z "${test | grep 'Operation failed...'}" ];then
+        if [ -z "$($test | grep 'Operation failed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(upgrade)\\e[36m..."
         else
@@ -160,7 +160,7 @@ function hassbian.developer.test.package {
 
         # Remove test...
         test=$(hassbian-config remove "$suite" --accept)
-        if [ -z "${test | grep 'Operation failed...'}" ];then
+        if [ -z "$($test | grep 'Operation failed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(remove)\\e[36m"
         else

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -49,23 +49,25 @@ function hassbian.developer.test.package {
   local testsuite=template
   local test
   local unattended
+  local cirun
 
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     # Only try this if running in a CI env.
+    cirun="--ci"
     echo "
     ------------------------------------------
     TESTING HOMEASSISTANT INSTALLATION
     ------------------------------------------
     "
     printf "\\e[36mTesting Suite: 'homeassistant'.................."
-    #test=$(hassbian-config install homeassistant --accept --ci)
-    hassbian-config install homeassistant --accept --ci
+    #test=$(hassbian-config install homeassistant --accept $cirun)
+    hassbian-config install homeassistant --accept $cirun
     if [ -z "$(echo $test | grep 'Operation failed...')" ];then
       ((pass+=1))
       printf "\\e[32mPASS(install)\\e[36m..."
     else
       ((fail+=1))
-      failedtests+=("hassbian-config install homeassistant --accept --ci")
+      failedtests+=("hassbian-config install homeassistant --accept $cirun")
       printf "\\e[31mFAIL(install)\\e[36m..."
       printf "%s\\n" "$test"
     fi
@@ -165,38 +167,38 @@ function hassbian.developer.test.package {
         if [ "$suite" == "homeassistant" ]; then
           printf "\\e[33mSKIP(install)\\e[36m..."
           else
-          test=$(hassbian-config install "$suite" --accept)
+          test=$(hassbian-config install "$suite" --accept $cirun)
           if [ -z "$(echo $test | grep 'Operation failed...')" ];then
             ((pass+=1))
             printf "\\e[32mPASS(install)\\e[36m..."
           else
             ((fail+=1))
-            failedtests+=("hassbian-config install $suite --accept")
+            failedtests+=("hassbian-config install $suite --accept $cirun")
             printf "\\e[31mFAIL(install)\\e[36m..."
             printf "%s\\n" "$test"
           fi
         fi
 
         # Upgrade test...
-        test=$(hassbian-config upgrade "$suite" --accept)
+        test=$(hassbian-config upgrade "$suite" --accept $cirun)
         if [ -z "$(echo $test | grep 'Operation failed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(upgrade)\\e[36m..."
         else
           ((fail+=1))
-          failedtests+=("hassbian-config upgrade $suite --accept")
+          failedtests+=("hassbian-config upgrade $suite --accept $cirun")
           printf "\\e[31mFAIL(upgrade)\\e[36m..."
           printf "%s\\n" "$test"
         fi
 
         # Remove test...
-        test=$(hassbian-config remove "$suite" --accept)
+        test=$(hassbian-config remove "$suite" --accept $cirun)
         if [ -z "$(echo $test | grep 'Operation failed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(remove)\\e[36m"
         else
           ((fail+=1))
-          failedtests+=("hassbian-config remove $suite --accept")
+          failedtests+=("hassbian-config remove $suite --accept $cirun")
           printf "\\e[31mFAIL(remove)\\e[36m"
           printf "%s\\n" "$test"
         fi

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -186,7 +186,8 @@ function hassbian.developer.test.package {
         fi
 
         # Remove test...
-        test=$(hassbian-config remove $suite --accept --ci)
+        hassbian-config remove $suite --accept --ci
+        #test=$(hassbian-config remove $suite --accept --ci)
         if [ ! -z "$(echo $test | grep 'Operation completed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(remove)\\e[36m"

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -49,31 +49,24 @@ function hassbian.developer.test.package {
   local testsuite=template
   local test
   local unattended
-  local cirun
-
-echo "$(hassbian.info.version.python)"
-which python
-which python3
-python3 -V
 
 
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     # Only try this if running in a CI env.
-    cirun="--ci"
     echo "
     ------------------------------------------
     TESTING HOMEASSISTANT INSTALLATION
     ------------------------------------------
     "
     printf "\\e[36mTesting Suite: 'homeassistant'.................."
-    #test=$(hassbian-config install homeassistant --accept "$cirun")
-    hassbian-config install homeassistant --accept "$cirun"
+    #test=$(hassbian-config install homeassistant --accept --ci)
+    hassbian-config install homeassistant --accept --ci
     if [ -z "$(echo $test | grep 'Operation failed...')" ];then
       ((pass+=1))
       printf "\\e[32mPASS(install)\\e[36m..."
     else
       ((fail+=1))
-      failedtests+=("hassbian-config install homeassistant --accept $cirun")
+      failedtests+=("hassbian-config install homeassistant --accept --ci")
       printf "\\e[31mFAIL(install)\\e[36m..."
       printf "%s\\n" "$test"
     fi
@@ -172,39 +165,39 @@ python3 -V
         # Install test...
         if [ "$suite" == "homeassistant" ]; then
           printf "\\e[33mSKIP(install)\\e[36m..."
-          else
-          test=$(hassbian-config install "$suite" --accept "$cirun")
+        else
+          test=$(hassbian-config install "$suite" --accept --ci)
           if [ -z "$(echo $test | grep 'Operation failed...')" ];then
             ((pass+=1))
             printf "\\e[32mPASS(install)\\e[36m..."
           else
             ((fail+=1))
-            failedtests+=("hassbian-config install $suite --accept $cirun")
+            failedtests+=("hassbian-config install $suite --accept --ci")
             printf "\\e[31mFAIL(install)\\e[36m..."
             printf "%s\\n" "$test"
           fi
         fi
 
         # Upgrade test...
-        test=$(hassbian-config upgrade "$suite" --accept "$cirun")
+        test=$(hassbian-config upgrade "$suite" --accept --ci)
         if [ -z "$(echo $test | grep 'Operation failed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(upgrade)\\e[36m..."
         else
           ((fail+=1))
-          failedtests+=("hassbian-config upgrade $suite --accept $cirun")
+          failedtests+=("hassbian-config upgrade $suite --accept --ci")
           printf "\\e[31mFAIL(upgrade)\\e[36m..."
           printf "%s\\n" "$test"
         fi
 
         # Remove test...
-        test=$(hassbian-config remove "$suite" --accept "$cirun")
+        test=$(hassbian-config remove "$suite" --accept --ci)
         if [ -z "$(echo $test | grep 'Operation failed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(remove)\\e[36m"
         else
           ((fail+=1))
-          failedtests+=("hassbian-config remove $suite --accept $cirun")
+          failedtests+=("hassbian-config remove $suite --accept --ci")
           printf "\\e[31mFAIL(remove)\\e[36m"
           printf "%s\\n" "$test"
         fi

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -50,6 +50,7 @@ function hassbian.developer.test.package {
   local test
   local unattended
 
+echo "CI:$HASSBIAN_RUNTIME_CI"
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     # Only try this if running in a CI env.
     echo "

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -60,8 +60,8 @@ function hassbian.developer.test.package {
     ------------------------------------------
     "
     printf "\\e[36mTesting Suite: 'homeassistant'.................."
-    #test=$(hassbian-config install homeassistant --accept $cirun)
-    hassbian-config install homeassistant --accept $cirun
+    #test=$(hassbian-config install homeassistant --accept "$cirun")
+    hassbian-config install homeassistant --accept "$cirun"
     if [ -z "$(echo $test | grep 'Operation failed...')" ];then
       ((pass+=1))
       printf "\\e[32mPASS(install)\\e[36m..."
@@ -167,7 +167,7 @@ function hassbian.developer.test.package {
         if [ "$suite" == "homeassistant" ]; then
           printf "\\e[33mSKIP(install)\\e[36m..."
           else
-          test=$(hassbian-config install "$suite" --accept $cirun)
+          test=$(hassbian-config install "$suite" --accept "$cirun")
           if [ -z "$(echo $test | grep 'Operation failed...')" ];then
             ((pass+=1))
             printf "\\e[32mPASS(install)\\e[36m..."
@@ -180,7 +180,7 @@ function hassbian.developer.test.package {
         fi
 
         # Upgrade test...
-        test=$(hassbian-config upgrade "$suite" --accept $cirun)
+        test=$(hassbian-config upgrade "$suite" --accept "$cirun")
         if [ -z "$(echo $test | grep 'Operation failed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(upgrade)\\e[36m..."
@@ -192,7 +192,7 @@ function hassbian.developer.test.package {
         fi
 
         # Remove test...
-        test=$(hassbian-config remove "$suite" --accept $cirun)
+        test=$(hassbian-config remove "$suite" --accept "$cirun")
         if [ -z "$(echo $test | grep 'Operation failed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(remove)\\e[36m"

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -96,27 +96,6 @@ function hassbian.developer.test.package {
 
   echo "
   ------------------------------------------
-  TESTING HASSBIAN-CONFIG SUITE OPERATIONS
-  ------------------------------------------
-  "
-  operations=('install' 'upgrade' 'remove')
-  for cmd in "${operations[@]}"; do
-    printf "\\e[36mTesting 'hassbian-config %s %s'............." "$cmd" "$testsuite"
-    test=$(hassbian-config "$cmd" "$testsuite" | grep "Operation failed...")
-    if [ -z "${test}" ];then
-      ((pass+=1))
-      printf "\\e[32mPASS\\n"
-    else
-      ((fail+=1))
-      failedtests+=("hassbian-config $cmd $testsuite")
-      printf "\\e[31mFAIL\\n"
-      printf "%s\\n" "$test"
-    fi
-  done
-  printf "\\e[0m\\n"
-
-  echo "
-  ------------------------------------------
   TESTING HASSBIAN-CONFIG CLI OPERATIONS
   ------------------------------------------
   "

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -62,12 +62,12 @@ function hassbian.developer.test.package {
     test=$(hassbian-config install homeassistant --accept --ci)
     if [ ! -z "$(echo $test | grep 'Operation completed...')" ];then
       ((pass+=1))
-      printf "\\e[32mPASS(install)\\e[36m..."
+      printf "\\e[32mPASS"
     else
       ((fail+=1))
       failedtests+=("hassbian-config install homeassistant --accept --ci")
-      printf "\\e[31mFAIL(install)\\e[36m..."
-      printf "%s\\n" "$test"
+      printf "\\e[31mFAIL"
+      printf "\n%s\\n" "$test"
     fi
     printf "\\e[0m\\n"
   fi
@@ -89,18 +89,14 @@ function hassbian.developer.test.package {
         [ "$function" == "hassbian.input.info" ] || \
         [ "$function" == "hassbian.input.text" ] || \
         [ "$function" == "hassbian.log.share" ] || \
-        [ "$function" == "hassbian.log.show" ] || \
         [ "$function" == "hassbian.suite.action.execute" ] || \
         [ "$function" == "hassbian.suite.action" ] || \
         [ "$function" == "hassbian.suite.helper.blockcheck" ] || \
         [ "$function" == "hassbian.suite.helper.exist" ] || \
         [ "$function" == "hassbian.suite.helper.install.node" ] || \
-        [ "$function" == "hassbian.suite.helper.install.pip" ] || \
         [ "$function" == "hassbian.suite.helper.manifest" ] || \
         [ "$function" == "hassbian.suite.info.installed" ] || \
         [ "$function" == "hassbian.suite.info.print" ] || \
-        [ "$function" == "hassbian.suite.verify.service" ] || \
-        [ "$function" == "hassbian.workaround.check" ] || \
         [ "$function" == "hassbian.workaround.pip.typeerror" ]; then
         printf "\\e[33mSKIP\\n"
 
@@ -173,7 +169,7 @@ function hassbian.developer.test.package {
             ((fail+=1))
             failedtests+=("hassbian-config install $suite --accept --ci")
             printf "\\e[31mFAIL(install)\\e[36m..."
-            printf "%s\\n" "$test"
+            printf "\\n%s\\n" "$test"
           fi
         fi
 
@@ -186,7 +182,7 @@ function hassbian.developer.test.package {
           ((fail+=1))
           failedtests+=("hassbian-config upgrade $suite --accept --ci")
           printf "\\e[31mFAIL(upgrade)\\e[36m..."
-          printf "%s\\n" "$test"
+          printf "\\n%s\\n" "$test"
         fi
 
         # Remove test...
@@ -198,7 +194,7 @@ function hassbian.developer.test.package {
           ((fail+=1))
           failedtests+=("hassbian-config remove $suite --accept --ci")
           printf "\\e[31mFAIL(remove)\\e[36m"
-          printf "%s\\n" "$test"
+          printf "\\n%s\\n" "$test"
         fi
       else
         printf "\\e[33mSKIP"

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -161,7 +161,7 @@ function hassbian.developer.test.package {
         if [ "$suite" == "homeassistant" ]; then
           printf "\\e[33mSKIP(install)\\e[36m..."
         else
-          test=$(hassbian-config install "$suite" --accept --ci)
+          test=$(hassbian-config install $suite --accept --ci)
           if [ ! -z "$(echo $test | grep 'Operation completed...')" ];then
             ((pass+=1))
             printf "\\e[32mPASS(install)\\e[36m..."
@@ -174,7 +174,7 @@ function hassbian.developer.test.package {
         fi
 
         # Upgrade test...
-        test=$(hassbian-config upgrade "$suite" --accept --ci)
+        test=$(hassbian-config upgrade $suite --accept --ci)
         if [ ! -z "$(echo $test | grep 'Operation completed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(upgrade)\\e[36m..."
@@ -186,7 +186,7 @@ function hassbian.developer.test.package {
         fi
 
         # Remove test...
-        test=$(hassbian-config remove "$suite" --accept --ci)
+        test=$(hassbian-config remove $suite --accept --ci)
         if [ ! -z "$(echo $test | grep 'Operation completed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(remove)\\e[36m"

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -50,7 +50,7 @@ function hassbian.developer.test.package {
   local test
   local unattended
 
-  if [ "$HASSBIAN_RUNTIME_CI" == "true" ];then
+  if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     # Only try this if running in a CI env.
     echo "
     ------------------------------------------
@@ -150,7 +150,7 @@ function hassbian.developer.test.package {
   done
   printf "\\e[0m\\n"
 
-  if [ "$HASSBIAN_RUNTIME_CI" == "true" ];then
+  if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     # Only try this if running in a CI env.
     echo "
     ------------------------------------------

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -87,7 +87,7 @@ function hassbian.developer.test.package {
           ((fail+=1))
           failedtests+=("$function")
           printf "\\e[31mFAIL\\n"
-          printf "\\s\\n" "$test"
+          printf "%s\\n" "$test"
         fi
       fi
     fi
@@ -110,7 +110,7 @@ function hassbian.developer.test.package {
       ((fail+=1))
       failedtests+=("hassbian-config $cmd $testsuite")
       printf "\\e[31mFAIL\\n"
-      printf "\\s\\n" "$test"
+      printf "%s\\n" "$test"
     fi
   done
   printf "\\e[0m\\n"
@@ -138,7 +138,7 @@ function hassbian.developer.test.package {
       ((fail+=1))
       failedtests+=("hassbian-config $operation")
       printf "\\e[31mFAIL\\n"
-      printf "\\s\\n" "$test"
+      printf "%s\\n" "$test"
     fi
   done
   printf "\\e[0m\\n"
@@ -163,7 +163,7 @@ function hassbian.developer.test.package {
           ((fail+=1))
           failedtests+=("hassbian-config install $suite --accept")
           printf "\\e[31mFAIL(install)\\e[36m..."
-          printf "\\s\\n" "$test"
+          printf "%s\\n" "$test"
         fi
 
         # Upgrade test...
@@ -175,7 +175,7 @@ function hassbian.developer.test.package {
           ((fail+=1))
           failedtests+=("hassbian-config upgrade $suite --accept")
           printf "\\e[31mFAIL(upgrade)\\e[36m..."
-          printf "\\s\\n" "$test"
+          printf "%s\\n" "$test"
         fi
 
         # Remove test...
@@ -187,7 +187,7 @@ function hassbian.developer.test.package {
           ((fail+=1))
           failedtests+=("hassbian-config remove $suite --accept")
           printf "\\e[31mFAIL(remove)\\e[36m"
-          printf "\\s\\n" "$test"
+          printf "%s\\n" "$test"
         fi
       else
         printf "\\e[33mSKIP"

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -67,19 +67,24 @@ function hassbian.developer.test.package {
         [ "$function" == "hassbian.input.info" ] || \
         [ "$function" == "hassbian.input.text" ] || \
         [ "$function" == "hassbian.log.share" ] || \
+        [ "$function" == "hassbian.log.show" ] || \
         [ "$function" == "hassbian.suite.action.execute" ] || \
         [ "$function" == "hassbian.suite.action" ] || \
-        [ "$function" == "hassbian.suite.helper.install.pip" ] || \
+        [ "$function" == "hassbian.suite.helper.blockcheck" ] || \
         [ "$function" == "hassbian.suite.helper.exist" ] || \
         [ "$function" == "hassbian.suite.helper.install.node" ] || \
-        [ "$function" == "hassbian.suite.helper.blockcheck" ] || \
+        [ "$function" == "hassbian.suite.helper.install.pip" ] || \
+        [ "$function" == "hassbian.suite.helper.manifest" ] || \
         [ "$function" == "hassbian.suite.info.installed" ] || \
+        [ "$function" == "hassbian.suite.info.print" ] || \
+        [ "$function" == "hassbian.suite.verify.service" ] || \
+        [ "$function" == "hassbian.workaround.check" ] || \
         [ "$function" == "hassbian.workaround.pip.typeerror" ]; then
         printf "\\e[33mSKIP\\n"
 
       # Run tests:
       else
-        test=$("$function")
+        test=$("$function" >> /dev/null 2>&1)
         returncode="$?"
         if [ "$returncode" == "0" ];then
           ((pass+=1))
@@ -136,7 +141,7 @@ function hassbian.developer.test.package {
       if [ "$unattended" == "true" ];then
         # Install test...
         test=$(hassbian-config install "$suite" --accept)
-        if [ -z "$($test | grep 'Operation failed...')" ];then
+        if [ -z "$(echo $test | grep 'Operation failed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(install)\\e[36m..."
         else
@@ -148,7 +153,7 @@ function hassbian.developer.test.package {
 
         # Upgrade test...
         test=$(hassbian-config upgrade "$suite" --accept)
-        if [ -z "$($test | grep 'Operation failed...')" ];then
+        if [ -z "$(echo $test | grep 'Operation failed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(upgrade)\\e[36m..."
         else
@@ -160,7 +165,7 @@ function hassbian.developer.test.package {
 
         # Remove test...
         test=$(hassbian-config remove "$suite" --accept)
-        if [ -z "$($test | grep 'Operation failed...')" ];then
+        if [ -z "$(echo $test | grep 'Operation failed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(remove)\\e[36m"
         else

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -135,8 +135,8 @@ function hassbian.developer.test.package {
       unattended=$(hassbian.suite.helper.manifest "$suite" unattended)
       if [ "$unattended" == "true" ];then
         # Install test...
-        test=$(hassbian-config install "$suite" --accept | grep "Operation failed...")
-        if [ -z "${test}" ];then
+        test=$(hassbian-config install "$suite" --accept)
+        if [ -z "${test | grep 'Operation failed...'}" ];then
           ((pass+=1))
           printf "\\e[32mPASS(install)\\e[36m..."
         else
@@ -147,8 +147,8 @@ function hassbian.developer.test.package {
         fi
 
         # Upgrade test...
-        test=$(hassbian-config upgrade "$suite" --accept | grep "Operation failed...")
-        if [ -z "${test}" ];then
+        test=$(hassbian-config upgrade "$suite" --accept)
+        if [ -z "${test | grep 'Operation failed...'}" ];then
           ((pass+=1))
           printf "\\e[32mPASS(upgrade)\\e[36m..."
         else
@@ -159,8 +159,8 @@ function hassbian.developer.test.package {
         fi
 
         # Remove test...
-        test=$(hassbian-config remove "$suite" --accept | grep "Operation failed...")
-        if [ -z "${test}" ];then
+        test=$(hassbian-config remove "$suite" --accept)
+        if [ -z "${test | grep 'Operation failed...'}" ];then
           ((pass+=1))
           printf "\\e[32mPASS(remove)\\e[36m"
         else

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -58,8 +58,8 @@ function hassbian.developer.test.package {
     ------------------------------------------
     "
     printf "\\e[36mTesting Suite: 'homeassistant'.................."
-    # Install test...
-    test=$(hassbian-config install homeassistant --accept)
+    #test=$(hassbian-config install homeassistant --accept)
+    hassbian-config install homeassistant --accept
     if [ -z "$(echo $test | grep 'Operation failed...')" ];then
       ((pass+=1))
       printf "\\e[32mPASS(install)\\e[36m..."

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -51,6 +51,10 @@ function hassbian.developer.test.package {
   local unattended
   local cirun
 
+echo "$(hassbian.info.version.python)"
+which python
+which python3
+
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     # Only try this if running in a CI env.
     cirun="--ci"

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -164,39 +164,38 @@ function hassbian.developer.test.package {
         if [ "$suite" == "homeassistant" ]; then
           printf "\\e[33mSKIP(install)\\e[36m..."
         else
-          test=$(hassbian-config install $suite --accept --ci)
+          test=$(hassbian.suite.action install "$suite")
           if [ ! -z "$(echo $test | grep 'Operation completed...')" ];then
             ((pass+=1))
             printf "\\e[32mPASS(install)\\e[36m..."
           else
             ((fail+=1))
-            failedtests+=("hassbian-config install $suite --accept --ci")
+            failedtests+=("hassbian.suite.action install $suite")
             printf "\\e[31mFAIL(install)\\e[36m..."
             printf "\\n%s\\n" "$test"
           fi
         fi
 
         # Upgrade test...
-        test=$(hassbian-config upgrade $suite --accept --ci)
+        test=$(hassbian.suite.action upgrade "$suite")
         if [ ! -z "$(echo $test | grep 'Operation completed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(upgrade)\\e[36m..."
         else
           ((fail+=1))
-          failedtests+=("hassbian-config upgrade $suite --accept --ci")
+          failedtests+=("hassbian.suite.action upgrade $suite")
           printf "\\e[31mFAIL(upgrade)\\e[36m..."
           printf "\\n%s\\n" "$test"
         fi
 
         # Remove test...
-        hassbian-config remove $suite --accept --ci
-        #test=$(hassbian-config remove $suite --accept --ci)
+        test=$(hassbian.suite.action remove "$suite")
         if [ ! -z "$(echo $test | grep 'Operation completed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(remove)\\e[36m"
         else
           ((fail+=1))
-          failedtests+=("hassbian-config remove $suite --accept --ci")
+          failedtests+=("hassbian.suite.action remove $suite")
           printf "\\e[31mFAIL(remove)\\e[36m"
           printf "\\n%s\\n" "$test"
         fi

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -52,26 +52,22 @@ function hassbian.developer.test.package {
 
   if [ "$HASSBIAN_RUNTIME_CI" == "true" ];then
     # Only try this if running in a CI env.
-  echo "
-  ------------------------------------------
-  TESTING HOMEASSISTANT INSTALLATION
-  ------------------------------------------
-  "
+    echo "
+    ------------------------------------------
+    TESTING HOMEASSISTANT INSTALLATION
+    ------------------------------------------
+    "
     printf "\\e[36mTesting Suite: 'homeassistant'.................."
-    unattended=$(hassbian.suite.helper.manifest homeassistant unattended)
-    if [ "$unattended" == "true" ];then
-      # Install test...
-      test=$(hassbian-config install homeassistant --accept)
-      if [ -z "$(echo $test | grep 'Operation failed...')" ];then
-        ((pass+=1))
-        printf "\\e[32mPASS(install)\\e[36m..."
-      else
-        ((fail+=1))
-        failedtests+=("hassbian-config install homeassistant --accept")
-        printf "\\e[31mFAIL(install)\\e[36m..."
-        printf "%s\\n" "$test"
-      fi
-      printf "\\e[33mSKIP"
+    # Install test...
+    test=$(hassbian-config install homeassistant --accept)
+    if [ -z "$(echo $test | grep 'Operation failed...')" ];then
+      ((pass+=1))
+      printf "\\e[32mPASS(install)\\e[36m..."
+    else
+      ((fail+=1))
+      failedtests+=("hassbian-config install homeassistant --accept")
+      printf "\\e[31mFAIL(install)\\e[36m..."
+      printf "%s\\n" "$test"
     fi
     printf "\\e[0m\\n"
   fi

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -53,19 +53,22 @@ function hassbian.developer.test.package {
 
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     # Only try this if running in a CI env.
+
+    HASSBIAN_RUNTIME_ACCEPT=true
+
     echo "
     ------------------------------------------
     TESTING HOMEASSISTANT INSTALLATION
     ------------------------------------------
     "
     printf "\\e[36mTesting Suite: 'homeassistant'.................."
-    test=$(hassbian-config install homeassistant --accept --ci)
+    test=$(hassbian.suite.action install homeassistant)
     if [ ! -z "$(echo $test | grep 'Operation completed...')" ];then
       ((pass+=1))
       printf "\\e[32mPASS"
     else
       ((fail+=1))
-      failedtests+=("hassbian-config install homeassistant --accept --ci")
+      failedtests+=("hassbian.suite.action install homeassistant")
       printf "\\e[31mFAIL"
       printf "\n%s\\n" "$test"
     fi

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -69,6 +69,7 @@ function hassbian.developer.test.package {
         [ "$function" == "hassbian.log.share" ] || \
         [ "$function" == "hassbian.suite.action.execute" ] || \
         [ "$function" == "hassbian.suite.action" ] || \
+        [ "$function" == "hassbian.suite.helper.install.pip" ] || \
         [ "$function" == "hassbian.suite.helper.exist" ] || \
         [ "$function" == "hassbian.suite.helper.install.node" ] || \
         [ "$function" == "hassbian.suite.info.installed" ] || \
@@ -77,7 +78,7 @@ function hassbian.developer.test.package {
 
       # Run tests:
       else
-        "$function" >> /dev/null 2>&1
+        test=$("$function")
         returncode="$?"
         if [ "$returncode" == "0" ];then
           ((pass+=1))
@@ -86,6 +87,7 @@ function hassbian.developer.test.package {
           ((fail+=1))
           failedtests+=("$function")
           printf "\\e[31mFAIL\\n"
+          printf "\\s\\n" "$test"
         fi
       fi
     fi
@@ -108,6 +110,7 @@ function hassbian.developer.test.package {
       ((fail+=1))
       failedtests+=("hassbian-config $cmd $testsuite")
       printf "\\e[31mFAIL\\n"
+      printf "\\s\\n" "$test"
     fi
   done
   printf "\\e[0m\\n"
@@ -135,6 +138,7 @@ function hassbian.developer.test.package {
       ((fail+=1))
       failedtests+=("hassbian-config $operation")
       printf "\\e[31mFAIL\\n"
+      printf "\\s\\n" "$test"
     fi
   done
   printf "\\e[0m\\n"
@@ -159,6 +163,7 @@ function hassbian.developer.test.package {
           ((fail+=1))
           failedtests+=("hassbian-config install $suite --accept")
           printf "\\e[31mFAIL(install)\\e[36m..."
+          printf "\\s\\n" "$test"
         fi
 
         # Upgrade test...
@@ -170,6 +175,7 @@ function hassbian.developer.test.package {
           ((fail+=1))
           failedtests+=("hassbian-config upgrade $suite --accept")
           printf "\\e[31mFAIL(upgrade)\\e[36m..."
+          printf "\\s\\n" "$test"
         fi
 
         # Remove test...
@@ -181,6 +187,7 @@ function hassbian.developer.test.package {
           ((fail+=1))
           failedtests+=("hassbian-config remove $suite --accept")
           printf "\\e[31mFAIL(remove)\\e[36m"
+          printf "\\s\\n" "$test"
         fi
       else
         printf "\\e[33mSKIP"

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -59,9 +59,8 @@ function hassbian.developer.test.package {
     ------------------------------------------
     "
     printf "\\e[36mTesting Suite: 'homeassistant'.................."
-    #test=$(hassbian-config install homeassistant --accept --ci)
-    hassbian-config install homeassistant --accept --ci
-    if [ -z "$(echo $test | grep 'Operation failed...')" ];then
+    test=$(hassbian-config install homeassistant --accept --ci)
+    if [ ! -z "$(echo $test | grep 'Operation completed...')" ];then
       ((pass+=1))
       printf "\\e[32mPASS(install)\\e[36m..."
     else
@@ -167,7 +166,7 @@ function hassbian.developer.test.package {
           printf "\\e[33mSKIP(install)\\e[36m..."
         else
           test=$(hassbian-config install "$suite" --accept --ci)
-          if [ -z "$(echo $test | grep 'Operation failed...')" ];then
+          if [ ! -z "$(echo $test | grep 'Operation completed...')" ];then
             ((pass+=1))
             printf "\\e[32mPASS(install)\\e[36m..."
           else
@@ -180,7 +179,7 @@ function hassbian.developer.test.package {
 
         # Upgrade test...
         test=$(hassbian-config upgrade "$suite" --accept --ci)
-        if [ -z "$(echo $test | grep 'Operation failed...')" ];then
+        if [ ! -z "$(echo $test | grep 'Operation completed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(upgrade)\\e[36m..."
         else
@@ -192,7 +191,7 @@ function hassbian.developer.test.package {
 
         # Remove test...
         test=$(hassbian-config remove "$suite" --accept --ci)
-        if [ -z "$(echo $test | grep 'Operation failed...')" ];then
+        if [ ! -z "$(echo $test | grep 'Operation completed...')" ];then
           ((pass+=1))
           printf "\\e[32mPASS(remove)\\e[36m"
         else

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -50,6 +50,32 @@ function hassbian.developer.test.package {
   local test
   local unattended
 
+  if [ "$HASSBIAN_RUNTIME_CI" == "true" ];then
+    # Only try this if running in a CI env.
+  echo "
+  ------------------------------------------
+  TESTING HOMEASSISTANT INSTALLATION
+  ------------------------------------------
+  "
+    printf "\\e[36mTesting Suite: 'homeassistant'.................."
+    unattended=$(hassbian.suite.helper.manifest homeassistant unattended)
+    if [ "$unattended" == "true" ];then
+      # Install test...
+      test=$(hassbian-config install homeassistant --accept)
+      if [ -z "$(echo $test | grep 'Operation failed...')" ];then
+        ((pass+=1))
+        printf "\\e[32mPASS(install)\\e[36m..."
+      else
+        ((fail+=1))
+        failedtests+=("hassbian-config install homeassistant --accept")
+        printf "\\e[31mFAIL(install)\\e[36m..."
+        printf "%s\\n" "$test"
+      fi
+      printf "\\e[33mSKIP"
+    fi
+    printf "\\e[0m\\n"
+  fi
+
   echo "
   ------------------------------------------
   TESTING HASSBIAN-CONFIG FUNCTIONS
@@ -140,15 +166,19 @@ function hassbian.developer.test.package {
       unattended=$(hassbian.suite.helper.manifest "$suite" unattended)
       if [ "$unattended" == "true" ];then
         # Install test...
-        test=$(hassbian-config install "$suite" --accept)
-        if [ -z "$(echo $test | grep 'Operation failed...')" ];then
-          ((pass+=1))
-          printf "\\e[32mPASS(install)\\e[36m..."
-        else
-          ((fail+=1))
-          failedtests+=("hassbian-config install $suite --accept")
-          printf "\\e[31mFAIL(install)\\e[36m..."
-          printf "%s\\n" "$test"
+        if [ "$suite" == "homeassistant" ]; then
+          printf "\\e[33mSKIP(install)\\e[36m..."
+          else
+          test=$(hassbian-config install "$suite" --accept)
+          if [ -z "$(echo $test | grep 'Operation failed...')" ];then
+            ((pass+=1))
+            printf "\\e[32mPASS(install)\\e[36m..."
+          else
+            ((fail+=1))
+            failedtests+=("hassbian-config install $suite --accept")
+            printf "\\e[31mFAIL(install)\\e[36m..."
+            printf "%s\\n" "$test"
+          fi
         fi
 
         # Upgrade test...
@@ -181,8 +211,6 @@ function hassbian.developer.test.package {
     done
     printf "\\e[0m\\n"
   fi
-
-
 
  # Testing is done.
   echo "

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -50,7 +50,6 @@ function hassbian.developer.test.package {
   local test
   local unattended
 
-echo "CI:$HASSBIAN_RUNTIME_CI"
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     # Only try this if running in a CI env.
     echo "
@@ -66,7 +65,7 @@ echo "CI:$HASSBIAN_RUNTIME_CI"
       printf "\\e[32mPASS(install)\\e[36m..."
     else
       ((fail+=1))
-      failedtests+=("hassbian-config install homeassistant --accept")
+      failedtests+=("hassbian-config install homeassistant --accept --ci")
       printf "\\e[31mFAIL(install)\\e[36m..."
       printf "%s\\n" "$test"
     fi

--- a/package/opt/hassbian/helpers/developer
+++ b/package/opt/hassbian/helpers/developer
@@ -72,6 +72,7 @@ function hassbian.developer.test.package {
         [ "$function" == "hassbian.suite.helper.install.pip" ] || \
         [ "$function" == "hassbian.suite.helper.exist" ] || \
         [ "$function" == "hassbian.suite.helper.install.node" ] || \
+        [ "$function" == "hassbian.suite.helper.blockcheck" ] || \
         [ "$function" == "hassbian.suite.info.installed" ] || \
         [ "$function" == "hassbian.workaround.pip.typeerror" ]; then
         printf "\\e[33mSKIP\\n"

--- a/package/opt/hassbian/helpers/info/general
+++ b/package/opt/hassbian/helpers/info/general
@@ -20,7 +20,11 @@ function hassbian.info.general.ipaddress {
   # Retrun the IP Address of the host.
   local ipaddress
   ipaddress=$(ifconfig | grep "inet.*broadcast" | grep -v 0.0.0.0 | awk '{print $2}')
-  printf "%s" "$ipaddress"
+  if [ "$?" == "0" ];then
+    printf "%s" "$ipaddress"
+  else
+    return 1
+  fi
 }
 
 function hassbian.info.general.help {

--- a/package/opt/hassbian/helpers/info/version
+++ b/package/opt/hassbian/helpers/info/version
@@ -76,11 +76,10 @@ function hassbian.info.version.python {
 
   for version in $potentialversions; do
     if [[ -n "$(command -v python"$version")" ]]; then
-      echo "$(command -v python"$version")"
       isntalledversion="$version"
     fi
   done
-  printf "%s" "${version}"
+  printf "%s" "${isntalledversion}"
 }
 
 function hassbian.info.version.osreleasename {

--- a/package/opt/hassbian/helpers/info/version
+++ b/package/opt/hassbian/helpers/info/version
@@ -87,7 +87,11 @@ function hassbian.info.version.osreleasename {
   local name
 
   name=$(lsb_release -cs)
-  printf "%s" "${name}"
+  if [ "$?" == "0" ];then
+    printf "%s" "${name}"
+  else
+    return 1
+  fi
 }
 
 [[ "$_" == "$0" ]] && echo "$ECHO_HELPER_WARNING"

--- a/package/opt/hassbian/helpers/info/version
+++ b/package/opt/hassbian/helpers/info/version
@@ -76,6 +76,7 @@ function hassbian.info.version.python {
 
   for version in $potentialversions; do
     if [[ -n "$(command -v python"$version")" ]]; then
+      echo "$(command -v python"$version")"
       isntalledversion="$version"
     fi
   done

--- a/package/opt/hassbian/helpers/log
+++ b/package/opt/hassbian/helpers/log
@@ -4,6 +4,9 @@
 function hassbian.log.show {
   # Show the logfile in the console.
   more "$HASSBIAN_LOG_FILE"
+  if [ "$?" != "0" ];then
+    return 1
+  fi
 }
 
 

--- a/package/opt/hassbian/helpers/suite/action
+++ b/package/opt/hassbian/helpers/suite/action
@@ -100,7 +100,7 @@ function hassbian.suite.action.execute {
   fi
 
   # Deactivate debug
-  if [ "$HASSBIAN_RUNTIME_DEBUG" == true ]; then set +x; fi
+  if [ "$HASSBIAN_RUNTIME_DEBUG" = true ]; then set +x; fi
 
   return "$returnvalue"
 }

--- a/package/opt/hassbian/helpers/suite/action
+++ b/package/opt/hassbian/helpers/suite/action
@@ -83,6 +83,7 @@ function hassbian.suite.action.execute {
     returnvalue="$?"
   else
     echo "$suiteaction script does not exist for this suite."
+    hassbian.suite.helper.action.success
   fi
 
   # Post action

--- a/package/opt/hassbian/helpers/suite/verify
+++ b/package/opt/hassbian/helpers/suite/verify
@@ -13,7 +13,7 @@ function hassbian.suite.verify.service {
   retrunvalue=1
 
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
-    return 0
+    printf "0"
   fi
 
   for i in {1..5}; do
@@ -36,7 +36,7 @@ function hassbian.suite.verify.pgrep {
   retrunvalue=1
 
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
-    return 0
+    printf "0"
   fi
 
   for i in {1..5}; do

--- a/package/opt/hassbian/helpers/suite/verify
+++ b/package/opt/hassbian/helpers/suite/verify
@@ -11,7 +11,7 @@ function hassbian.suite.verify.service {
 
   servicename="$1"
   retrunvalue=1
-
+  echo "CI: $HASSBIAN_RUNTIME_CI"
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     printf "0"
     return

--- a/package/opt/hassbian/helpers/suite/verify
+++ b/package/opt/hassbian/helpers/suite/verify
@@ -14,6 +14,7 @@ function hassbian.suite.verify.service {
 
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     printf "0"
+    return
   fi
 
   for i in {1..5}; do
@@ -37,6 +38,7 @@ function hassbian.suite.verify.pgrep {
 
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     printf "0"
+    return
   fi
 
   for i in {1..5}; do

--- a/package/opt/hassbian/helpers/suite/verify
+++ b/package/opt/hassbian/helpers/suite/verify
@@ -11,7 +11,7 @@ function hassbian.suite.verify.service {
 
   servicename="$1"
   retrunvalue=1
-  echo "CI: $HASSBIAN_RUNTIME_CI"
+
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     printf "0"
     return

--- a/package/opt/hassbian/helpers/suite/verify
+++ b/package/opt/hassbian/helpers/suite/verify
@@ -12,6 +12,10 @@ function hassbian.suite.verify.service {
   servicename="$1"
   retrunvalue=1
 
+  if [ "$HASSBIAN_RUNTIME_CI" = true ];then
+    return 0
+  fi
+
   for i in {1..5}; do
     if [ "$(systemctl is-active "$servicename")" == "active" ]; then
       retrunvalue=0
@@ -30,6 +34,10 @@ function hassbian.suite.verify.pgrep {
 
   prosessename="$1"
   retrunvalue=1
+
+  if [ "$HASSBIAN_RUNTIME_CI" = true ];then
+    return 0
+  fi
 
   for i in {1..5}; do
     if [ ! -z  "$(pgrep -f "$prosessename")" ]; then

--- a/package/opt/hassbian/suites/homeassistant/manifest
+++ b/package/opt/hassbian/suites/homeassistant/manifest
@@ -3,6 +3,7 @@
   "author": "Lindqvist <https://github.com/Landrash>",
   "short_description": "Home Assistant install script for Hassbian.",
   "long_description": "Installs the base homeassistant package onto this system.",
+  "unattended": true,
   "blocked": false,
   "blocked_releasename": "",
   "blocked_messages": ""

--- a/package/opt/hassbian/suites/homeassistant/python-migration
+++ b/package/opt/hassbian/suites/homeassistant/python-migration
@@ -64,7 +64,7 @@ function python-migration {
   "
   sleep 20  # To give the user the option to panic and abort thr progress.
   source "$HASSBIAN_SUITE_DIR/python/upgrade"
-  install
+  upgrade
   echo "HAVENV=$currenthapyversion" > "$pythonmigrationfile"
   exit
 }

--- a/package/opt/hassbian/suites/homeassistant/python-migration
+++ b/package/opt/hassbian/suites/homeassistant/python-migration
@@ -20,7 +20,7 @@ function python-migration {
   force="$1"
 
   # Skip migration check if CI env
-  if [ "$HASSBIAN_RUNTIME_CI" == "true" ];then
+  if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     return 0
   fi
 

--- a/package/opt/hassbian/suites/homeassistant/python-migration
+++ b/package/opt/hassbian/suites/homeassistant/python-migration
@@ -20,7 +20,6 @@ function python-migration {
   force="$1"
 
   # Skip migration check if CI env
-  echo "CI:$HASSBIAN_RUNTIME_CI"
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     echo "HASSBIAN_RUNTIME_CI enabled, skipping check..."
     return 0

--- a/package/opt/hassbian/suites/homeassistant/python-migration
+++ b/package/opt/hassbian/suites/homeassistant/python-migration
@@ -9,8 +9,8 @@ function python-migration {
   # Implemented to cope with the announced D-Day of Python 3.5
   # To track if this allready have been run, we create a file to hold that "state"
   # /srv/homeassistant/hassbian/pythonmigration with HAVENV=pythonversion as the content.
-  readonly pythonmigrationfile="$HOME_ASSISTANT_VENV/hassbian/pythonmigration"
-  readonly targetpythonversion="3.7"
+  local pythonmigrationfile="$HOME_ASSISTANT_VENV/hassbian/pythonmigration"
+  local targetpythonversion="3.7"
   local force
   local pyversion
   local currenthapyversion
@@ -63,7 +63,7 @@ function python-migration {
 
   "
   sleep 20  # To give the user the option to panic and abort thr progress.
-  source "$HASSBIAN_SUITE_DIR/python/install"
+  source "$HASSBIAN_SUITE_DIR/python/upgrade"
   install
   echo "HAVENV=$currenthapyversion" > "$pythonmigrationfile"
   exit

--- a/package/opt/hassbian/suites/homeassistant/python-migration
+++ b/package/opt/hassbian/suites/homeassistant/python-migration
@@ -21,6 +21,7 @@ function python-migration {
 
   # Skip migration check if CI env
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
+    echo "HASSBIAN_RUNTIME_CI enabled, skipping check..."
     return 0
   fi
 

--- a/package/opt/hassbian/suites/homeassistant/python-migration
+++ b/package/opt/hassbian/suites/homeassistant/python-migration
@@ -19,6 +19,11 @@ function python-migration {
 
   force="$1"
 
+  # Skip migration check if CI env
+  if [ "$HASSBIAN_RUNTIME_CI" == "true" ];then
+    return 0
+  fi
+
   # Get the current python version HA is running under.
   currenthapyversion=$(hassbian.info.version.homeassistant.python)
 

--- a/package/opt/hassbian/suites/homeassistant/python-migration
+++ b/package/opt/hassbian/suites/homeassistant/python-migration
@@ -20,6 +20,7 @@ function python-migration {
   force="$1"
 
   # Skip migration check if CI env
+  echo "CI:$HASSBIAN_RUNTIME_CI"
   if [ "$HASSBIAN_RUNTIME_CI" = true ];then
     echo "HASSBIAN_RUNTIME_CI enabled, skipping check..."
     return 0

--- a/package/opt/hassbian/suites/hue/manifest
+++ b/package/opt/hassbian/suites/hue/manifest
@@ -3,6 +3,7 @@
   "author": "Landrash <https://github.com/Landrash>",
   "short_description": "Echo/Mycroft Emulated Hue install script for Hassbian.",
   "long_description": "Configures the Python executable to allow usage of low numbered\\nports for use with Amazon Echo or Mycroft.ai.",
+  "unattended": true,
   "blocked": false,
   "blocked_releasename": "",
   "blocked_messages": ""

--- a/package/opt/hassbian/suites/mosquitto/manifest
+++ b/package/opt/hassbian/suites/mosquitto/manifest
@@ -3,6 +3,7 @@
   "author": "Landrash <https://github.com/Landrash>",
   "short_description": "Mosquitto Installer for Hassbian.",
   "long_description": "Installs the Mosquitto package for setting up a local MQTT server.",
+  "unattended": true,
   "blocked": false,
   "blocked_releasename": "",
   "blocked_messages": ""

--- a/package/opt/hassbian/suites/python/upgrade
+++ b/package/opt/hassbian/suites/python/upgrade
@@ -12,7 +12,7 @@ function upgrade {
   remotepyversion=$(curl -s https://www.python.org/downloads/source/ | \
     grep "Latest Python 3 Release" | cut -d "<" -f 3 | awk -F ' ' '{print $NF}')
 
-  echo "Checking current pythin version..."
+  echo "Checking current python version..."
   hapyversion=$(hassbian.info.version.homeassistant.python)
 
   if [ "$hapyversion" == "$remotepyversion" ]; then


### PR DESCRIPTION
## Description:

- Changes to test suite for it to better work in a container setup (CI)
- Bugfix for returned python version.
- Bugfix for a loop in python migration on stretch.
- Added CI testing for Homeassistant, hue and mosquitto.

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist (Required):
  - [x] The code change is tested and works locally.
  - [x] The code is compliant with [Contributing guidelines](https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md)
<!--
### If pertinent:
  - [ ] Script has validation check of the job.
  - [ ] Created/Updated documentation at `/docs`
-->