### PR TITLE
AppDaemon: Fixes "command not found" when running suite actions.

### DIFF
--- a/package/opt/hassbian/suites/appdaemon/install
+++ b/package/opt/hassbian/suites/appdaemon/install
@@ -41,6 +41,7 @@ function install {
     python -m pip install setuptools wheel
     python -m pip install appdaemon
 
+    source "$HASSBIAN_HELPERS_DIR"/workaround
     hassbian.workaround.check appdaemon
 
     echo "Copying AppDaemon config file..."

--- a/package/opt/hassbian/suites/appdaemon/upgrade
+++ b/package/opt/hassbian/suites/appdaemon/upgrade
@@ -18,6 +18,7 @@ function upgrade {
     python -m pip install --upgrade setuptools wheel
     python -m pip install --upgrade appdaemon
 
+    source "$HASSBIAN_HELPERS_DIR"/workaround
     hassbian.workaround.check appdaemon
 
     echo "Deactivating virtualenv..."


### PR DESCRIPTION
# Description

Fixes issue described on [Discord](https://discordapp.com/channels/330944238910963714/332318336111214602/574356700274884627).

```bash
/bin/bash: line 15: hassbian.workaround.check: command not found
Copying AppDaemon config file...
Deactivating virtualenv...
Copying AppDaemon service file
Enabling AppDaemon service
Created symlink /etc/systemd/system/multi-user.target.wants/appdaemon@homeassistant.service → /etc/systemd/system/appdaemon@homeassistant.service.
Starting AppDaemon service
```

<!-- Fill out a description to what this PR adds/changes.

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>
 -->
## Checklist

<!-- 
Comment out the sections that does not apply like this comment.
For changes to documentation only, you can comment out all sections.
-->
<!-- 
### New suite

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Script has validation check of the job.
- [ ] Created documentation at `/docs/suites`
-->
### Change to existing suite

- [x] The code change is tested and works locally.
- [x] The code is compliant with [Contributing guidelines][guidelines]
- ~~Updated documentation at `/docs/suites`~~
<!-- 
### New function

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Script has validation check of the job.
- [ ] Created documentation at `/docs/cli`

### Change to existing function

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Updated documentation at `/docs/cli`
-->
[guidelines]: https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md