### PR TITLE
Fix color if new update

### DIFF
--- a/package/opt/hassbian/helpers/info/general
+++ b/package/opt/hassbian/helpers/info/general
@@ -85,7 +85,7 @@ function hassbian.info.general.systeminfo {
   "
 
   if [ "$hcversion" != "$hcversionremote" ]; then
-    printf "\\e[31m%s\\n" "
+    printf "\\e[31m%s\\n\\e[0m" "
     There is an update pending for 'hassbian-config'
     You can upgrade by running this:
       sudo hassbian-config upgrade hassbian-script


### PR DESCRIPTION
# Description

Cahnges the color back to white after warning about a new version.

<!-- Fill out a description to what this PR adds/changes. 

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>
-->
## Checklist

<!-- 
Comment out the sections that does not apply like this comment.
For changes to documentation only, you can comment out all sections.
-->
<!-- 
### New suite

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Script has validation check of the job.
- [ ] Created documentation at `/docs/suites`
-->
### Change to existing suite

- [x] The code change is tested and works locally.
- [x] The code is compliant with [Contributing guidelines][guidelines]
- ~~Updated documentation at `/docs/suites`~~
<!-- 
### New function

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Script has validation check of the job.
- [ ] Created documentation at `/docs/cli`

### Change to existing function

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Updated documentation at `/docs/cli`
-->
[guidelines]: https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md