### PR TITLE
homeassistant: Fix for upgrade using beta/dev flags

### DIFF
--- a/package/opt/hassbian/suites/homeassistant/upgrade
+++ b/package/opt/hassbian/suites/homeassistant/upgrade
@@ -49,10 +49,12 @@ function upgrade {
   fi
 
   # Check if we need an update.
-  if [[ "$newversion" == "$(hassbian.info.version.homeassistant.installed)" ]]; then 
-    echo "You already have version: $newversion"
-    hassbian.suite.helper.action.success
-    exit
+  if [ "$HASSBIAN_RUNTIME_BETA" = false  ] && [ "$HASSBIAN_RUNTIME_DEV" = false  ]; then
+    if [[ "$newversion" == "$(hassbian.info.version.homeassistant.installed)" ]]; then 
+      echo "You already have version: $newversion"
+      hassbian.suite.helper.action.success
+      exit
+    fi
   fi
 
   echo "Setting correct premissions"


### PR DESCRIPTION
# Description

Fixes issue with using --dev / --beta flags to upgrade.
<!-- Fill out a description to what this PR adds/changes. 

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>
-->
## Checklist

<!-- 
Comment out the sections that does not apply like this comment.
For changes to documentation only, you can comment out all sections.
-->

### Change to existing suite

- [x] The code change is tested and works locally.
- [x] The code is compliant with [Contributing guidelines][guidelines]
- ~~Updated documentation at `/docs/suites`~~

[guidelines]: https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md