### PR TITLE
input.text fix returned value

### DIFF
--- a/package/opt/hassbian/helpers/input
+++ b/package/opt/hassbian/helpers/input
@@ -28,9 +28,11 @@ function hassbian.input.text {
   # Present a pretty GUI for your question.
   # Usage example:
   # hassbian.input.text "Define a username:"
+  local result
 
   message="$1"
   whiptail --title "hassbian-config" --inputbox "$message" 0 0 3>&1 1>&2 2>&3
-  printf "%s" "$?"
+  result=$?
+  printf "%s" "${result::-1}"
 }
 [[ "$_" == "$0" ]] && echo "$ECHO_HELPER_WARNING"


### PR DESCRIPTION
# Description

Strips `0` at the end of the returned value.

## Checklist

### Change to existing function

- [x] The code change is tested and works locally.
- [x] The code is compliant with [Contributing guidelines][guidelines]

[guidelines]: https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md