### PR TITLE
Spelling correction premissions->permissions

### DIFF
--- a/package/opt/hassbian/suites/homeassistant/install
+++ b/package/opt/hassbian/suites/homeassistant/install
@@ -18,7 +18,7 @@ function install {
     python-migration true # 'true' forces the migration to run.
   fi
 
-  echo "Setting correct premissions"
+  echo "Setting correct permissions"
   chown homeassistant:homeassistant -R "$HOME_ASSISTANT_VENV"
 
   pythonversion=$(hassbian.info.version.python)

--- a/package/opt/hassbian/suites/homeassistant/upgrade
+++ b/package/opt/hassbian/suites/homeassistant/upgrade
@@ -57,7 +57,7 @@ function upgrade {
     fi
   fi
 
-  echo "Setting correct premissions"
+  echo "Setting correct permissions"
   chown homeassistant:homeassistant -R /srv/homeassistant
 
   echo "Upgrading Home Assistant"

--- a/package/opt/hassbian/suites/python/upgrade
+++ b/package/opt/hassbian/suites/python/upgrade
@@ -66,7 +66,7 @@ function upgrade {
     mkdir "$HOME_ASSISTANT_VENV"/hassbian \
     mkdir "$HOME_ASSISTANT_VENV"/hassbian/control
 
-  echo "Setting premissions..."
+  echo "Setting permissions..."
   chown homeassistant:homeassistant -R "$HOME_ASSISTANT_VENV"
 
   echo "Reinstalling Home Assistant..."


### PR DESCRIPTION
# Description

Misspelling of 'permissions' in several files

## Checklist

Comment out the sections that does not apply like this comment.
For changes to documentation only, you can comment out all sections.

<!-- 
### New suite

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Script has validation check of the job.
- [ ] Created documentation at `/docs/suites`
-->
### Change to existing suite

- [ x] The code change is tested and works locally.
- [ x] The code is compliant with [Contributing guidelines][guidelines]
- ~~[ ] Updated documentation at `/docs/suites`~~

<!-- 
### New function

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Script has validation check of the job.
- [ ] Created documentation at `/docs/cli`

### Change to existing function

- [x ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- ~~ [ ] Updated documentation at `/docs/cli` ~~

-->
[guidelines]: https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md