### PR TITLE
Added notice about Buster

### DIFF
--- a/docs/suites/pihole.md
+++ b/docs/suites/pihole.md
@@ -19,6 +19,11 @@ sudo hassbian-config install pihole
 
 Upgrades are handled by the Pi-hole software
 
+## Notice
+
+Due to an ongoing upstream issue, PiHole is currently unavailable in Debian Buster based systems.
+See: https://github.com/home-assistant/hassbian-scripts/issues/286
+
 ## Additional info
 
 Description | Command/value


### PR DESCRIPTION
PiHole is currently unavailable in Buster. Since this is an ongoing issues that has no resolution eta, it's worth pointing out to people as it will save them some time. It may also lead to one or two people nudging the PiHole devs to look into the issue.

# Description

<!-- Fill out a description to what this PR adds/changes. -->

**Related issue (if applicable):** Fixes #<hassbian-scripts issue number goes here>

## Checklist

<!-- 
Comment out the sections that does not apply like this comment.
For changes to documentation only, you can comment out all sections.
-->

### New suite

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Script has validation check of the job.
- [ ] Created documentation at `/docs/suites`

### Change to existing suite

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Updated documentation at `/docs/suites`

### New function

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Script has validation check of the job.
- [ ] Created documentation at `/docs/cli`

### Change to existing function

- [x] The code change is tested and works locally.
- [x] The code is compliant with [Contributing guidelines][guidelines]
- [x] Updated documentation at `/docs/cli`

[guidelines]: https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md